### PR TITLE
package.json に packageManager を指定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Outline
package.json に `packageManager` を指定すると、開発環境構築 / 後から CI を走らせる際に
一発でパッケージマネージャーのセットアップができて便利なので指定します

