### PR TITLE
fix: add text wrapping to element with long text children

### DIFF
--- a/app/components/note/Note.tsx
+++ b/app/components/note/Note.tsx
@@ -40,7 +40,7 @@ export const Note = ({ note }: NoteProps) => {
           <span>ノートの作成日時: {dateString}</span>
         </Group>
         <Stack gap="xs">
-          <Text>{note.summary}</Text>
+          <Text className="break-words">{note.summary}</Text>
           <NoteStatus status={note.currentStatus} />
           <div className="grid grid-cols-1 gap-2 md:grid-cols-[auto_1fr] md:gap-4">
             <Badge

--- a/app/components/post/Post.tsx
+++ b/app/components/post/Post.tsx
@@ -40,7 +40,7 @@ export const Post = ({ post }: PostProps) => {
           />
           <Text fw="bolder">{post.xUser.name}</Text>
         </Group>
-        <Text>{post.text}</Text>
+        <Text className="break-words">{post.text}</Text>
         {post.links?.map((link, index) => (
           <a href={link.url} key={`${post.postId}link_${index}`}>
             <Text c="blue">{link.url}</Text>


### PR DESCRIPTION
## やりたいこと
現状 https://birdxplorer.code4japan.org/?limit=25&offset=25 の最初の Note のように、
長い url などが含まれているときに折り返しがかかっていないので内容が隠れている。

ユーザーの入力によって内容が変わる Post / Note の本文に対してテキスト折り返しの設定を入れてこれを回避したい。

![image](https://github.com/user-attachments/assets/2a2ab418-4ecc-40ef-8de2-6177be015a39)


## やったこと
- Post, Note の本文を表示するコンポーネントに `overflow-wrap: break-word;` をつけた