### PR TITLE
refactor: build x url without post

### DIFF
--- a/app/components/note/Note.tsx
+++ b/app/components/note/Note.tsx
@@ -2,8 +2,11 @@ import { Badge, Button, Card, Group, Stack, Text } from "@mantine/core";
 import { useMemo } from "react";
 
 import { LANGUAGE_ID_TO_LABEL } from "../../feature/search/language";
+import {
+  birdWatchLinkFromNote,
+  postLinkFromNote,
+} from "../../feature/twitter/link-builder";
 import type { SearchedNote } from "../../generated/api/schemas";
-import { birdWatchLinkFromNote, postLinkFromNote } from "../../lib/twitter";
 import { Post } from "../post/Post";
 import { NoteStatus } from "./NoteStatus";
 import { NoteTopic } from "./NoteTopics";

--- a/app/components/note/Note.tsx
+++ b/app/components/note/Note.tsx
@@ -3,8 +3,8 @@ import { useMemo } from "react";
 
 import { LANGUAGE_ID_TO_LABEL } from "../../feature/search/language";
 import {
-  birdWatchLinkFromNote,
-  postLinkFromNote,
+  birdWatchLinkFromPostId,
+  postLinkFromPostId,
 } from "../../feature/twitter/link-builder";
 import type { SearchedNote } from "../../generated/api/schemas";
 import { isNonEmptyString } from "../../utils/string";
@@ -66,7 +66,7 @@ export const Note = ({ note }: NoteProps) => {
             <Button
               color="pink"
               component="a"
-              href={postLinkFromNote(note)}
+              href={postLinkFromPostId(note.postId)}
               size="xs"
               target="_blank"
               variant="light"
@@ -76,7 +76,7 @@ export const Note = ({ note }: NoteProps) => {
             <Button
               color="pink"
               component="a"
-              href={birdWatchLinkFromNote(note)}
+              href={birdWatchLinkFromPostId(note.postId)}
               size="xs"
               target="_blank"
               variant="light"

--- a/app/components/note/Note.tsx
+++ b/app/components/note/Note.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 
 import { LANGUAGE_ID_TO_LABEL } from "../../feature/search/language";
 import type { SearchedNote } from "../../generated/api/schemas";
+import { birdWatchLinkFromNote, postLinkFromNote } from "../../lib/twitter";
 import { Post } from "../post/Post";
 import { NoteStatus } from "./NoteStatus";
 import { NoteTopic } from "./NoteTopics";
@@ -60,7 +61,7 @@ export const Note = ({ note }: NoteProps) => {
           <Button
             color="pink"
             component="a"
-            href={note.post.link}
+            href={postLinkFromNote(note)}
             size="xs"
             target="_blank"
             variant="light"
@@ -70,7 +71,7 @@ export const Note = ({ note }: NoteProps) => {
           <Button
             color="pink"
             component="a"
-            href={`https://x.com/i/birdwatch/t/${note.post.postId}`}
+            href={birdWatchLinkFromNote(note)}
             size="xs"
             target="_blank"
             variant="light"

--- a/app/components/note/Note.tsx
+++ b/app/components/note/Note.tsx
@@ -7,6 +7,7 @@ import {
   postLinkFromNote,
 } from "../../feature/twitter/link-builder";
 import type { SearchedNote } from "../../generated/api/schemas";
+import { isNonEmptyString } from "../../utils/string";
 import { Post } from "../post/Post";
 import { NoteStatus } from "./NoteStatus";
 import { NoteTopic } from "./NoteTopics";
@@ -60,28 +61,30 @@ export const Note = ({ note }: NoteProps) => {
           </div>
         </Stack>
         <Post post={note.post} />
-        <Group justify="flex-end">
-          <Button
-            color="pink"
-            component="a"
-            href={postLinkFromNote(note)}
-            size="xs"
-            target="_blank"
-            variant="light"
-          >
-            ポストを見る
-          </Button>
-          <Button
-            color="pink"
-            component="a"
-            href={birdWatchLinkFromNote(note)}
-            size="xs"
-            target="_blank"
-            variant="light"
-          >
-            このポストについたノートを見る
-          </Button>
-        </Group>
+        {isNonEmptyString(note.postId) && (
+          <Group justify="flex-end">
+            <Button
+              color="pink"
+              component="a"
+              href={postLinkFromNote(note)}
+              size="xs"
+              target="_blank"
+              variant="light"
+            >
+              ポストを見る
+            </Button>
+            <Button
+              color="pink"
+              component="a"
+              href={birdWatchLinkFromNote(note)}
+              size="xs"
+              target="_blank"
+              variant="light"
+            >
+              このポストについたノートを見る
+            </Button>
+          </Group>
+        )}
       </Stack>
     </Card>
   );

--- a/app/feature/twitter/link-builder.ts
+++ b/app/feature/twitter/link-builder.ts
@@ -1,10 +1,8 @@
-import type { Note } from "../../generated/api/schemas";
-
-export const birdWatchLinkFromNote = (note: Note): string => {
-  return `https://x.com/i/birdwatch/t/${note.postId}`;
+export const birdWatchLinkFromPostId = (postId: string): string => {
+  return `https://x.com/i/birdwatch/t/${postId}`;
 };
 
-export const postLinkFromNote = (note: Note): string => {
+export const postLinkFromPostId = (postId: string): string => {
   // X redirects to correct post url regardless of userId, so just specify `i`
-  return `https://x.com/i/status/${note.postId}`;
+  return `https://x.com/i/status/${postId}`;
 };

--- a/app/feature/twitter/link-builder.ts
+++ b/app/feature/twitter/link-builder.ts
@@ -1,4 +1,4 @@
-import type { Note } from "../generated/api/schemas";
+import type { Note } from "../../generated/api/schemas";
 
 export const birdWatchLinkFromNote = (note: Note): string => {
   return `https://x.com/i/birdwatch/t/${note.postId}`;

--- a/app/lib/twitter.ts
+++ b/app/lib/twitter.ts
@@ -1,0 +1,10 @@
+import type { Note } from "../generated/api/schemas";
+
+export const birdWatchLinkFromNote = (note: Note): string => {
+  return `https://x.com/i/birdwatch/t/${note.postId}`;
+};
+
+export const postLinkFromNote = (note: Note): string => {
+  // X redirects to correct post url regardless of userId, so just specify `i`
+  return `https://x.com/i/status/${note.postId}`;
+};

--- a/app/utils/string.ts
+++ b/app/utils/string.ts
@@ -1,0 +1,2 @@
+export const isNonEmptyString = (value?: unknown): value is string =>
+  typeof value === "string" && value !== "";


### PR DESCRIPTION
- issue: #17 

上記 issue の内容に関連し、今後 `Note.post` が null になることがある。
この事前対応として、Note が Post 情報を含んでいなくても既存の URL ボタンが今まで通り動作するように変更した

また、API の仕様変更タイミングで `postId` に null が入った場合に備えて postId が null なら UI をそもそも出さないようにした

| postId があるとき | postId が null or 空文字列 |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ee989a66-a7a0-4230-908b-bf6672e8ce39) | ![image](https://github.com/user-attachments/assets/69226919-98ef-4f55-a561-5592138f310b) |