### PR TITLE
build: specify remix explicitly

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "remix",
+  "regions": ["hnd1"]
+}


### PR DESCRIPTION
#33 の影響で Vercel の管理画面で framework を react-router に設定した結果 prod build が落ちるようになった。
対策として `vercel.json` をデプロイごとの SSoT として扱う