### PR TITLE
fix: 同じクエリパラメータを 2 回以上指定した場合のページネーション計算

### DIFF
--- a/app/feature/search/pagination.test.ts
+++ b/app/feature/search/pagination.test.ts
@@ -82,4 +82,23 @@ describe("buildPaginationMeta", () => {
 
     expect(prevQuery).toBe(null);
   });
+
+  test("API 修正前ロジック: 次のページが存在しない場合に next が null になる", () => {
+    const currentQuery = {
+      post_includes_text: "地震",
+      limit: 10,
+      offset: 10,
+    } satisfies z.infer<typeof noteSearchParamSchema>;
+
+    // API が limit, offset 以外のクエリパラメータを削除してしまう挙動を再現
+    const currentBrokenMeta = {
+      next: null,
+      prev: "https://example.com/api/v1/data/search?offset=0&limit=10",
+    } satisfies PaginationMeta;
+
+    const fixedMeta = buildPaginationMeta(currentBrokenMeta, currentQuery);
+    const nextQuery = fixedMeta.next ? getQuery(fixedMeta.next) : null;
+
+    expect(nextQuery).toBe(null);
+  });
 });

--- a/app/feature/search/pagination.test.ts
+++ b/app/feature/search/pagination.test.ts
@@ -101,4 +101,33 @@ describe("buildPaginationMeta", () => {
 
     expect(nextQuery).toBe(null);
   });
+
+  test("API修正前ロジック: 同じクエリパラメータが 2 回以上指定されていてもそのまま処理できる", () => {
+    const currentQuery = {
+      note_status: ["CURRENTLY_RATED_HELPFUL", "NEEDS_MORE_RATINGS"],
+      limit: 10,
+      offset: 10,
+    } satisfies z.infer<typeof noteSearchParamSchema>;
+
+    const currentBrokenMeta = {
+      // API が note_status を複数回指定した際、最後のもの以外を削除してしまう挙動を再現
+      next: "https://example.com/api/v1/data/search?note_status=NEEDS_MORE_RATINGS&limit=10&offset=20",
+      prev: "https://example.com/api/v1/data/search?note_status=NEEDS_MORE_RATINGS&limit=10&offset=0",
+    } satisfies PaginationMeta;
+
+    const fixedMeta = buildPaginationMeta(currentBrokenMeta, currentQuery);
+    const prevQuery = fixedMeta.prev ? getQuery(fixedMeta.prev) : null;
+    const nextQuery = fixedMeta.next ? getQuery(fixedMeta.next) : null;
+
+    expect(prevQuery).toStrictEqual({
+      note_status: ["CURRENTLY_RATED_HELPFUL", "NEEDS_MORE_RATINGS"],
+      limit: "10",
+      offset: "0",
+    });
+    expect(nextQuery).toStrictEqual({
+      note_status: ["CURRENTLY_RATED_HELPFUL", "NEEDS_MORE_RATINGS"],
+      limit: "10",
+      offset: "20",
+    });
+  });
 });

--- a/app/feature/search/pagination.ts
+++ b/app/feature/search/pagination.ts
@@ -42,9 +42,13 @@ export const buildPaginationMeta = (
   const baseUrl = stringifyParsedURL(url);
 
   return {
-    next: withQuery(baseUrl, { ...rest, limit, offset: nextOffset }),
-    prev: isFirstPage
-      ? null
-      : withQuery(baseUrl, { ...rest, limit, offset: prevOffset }),
+    next:
+      meta.next != null
+        ? withQuery(baseUrl, { ...rest, limit, offset: nextOffset })
+        : null,
+    prev:
+      isFirstPage || meta.prev == null
+        ? null
+        : withQuery(baseUrl, { ...rest, limit, offset: prevOffset }),
   };
 };


### PR DESCRIPTION
- #52 の止血対応
- 根本対応は https://github.com/codeforjapan/BirdXplorer/issues/146 で行う