### PR TITLE
fix: rm default attribute

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_component.yml
+++ b/.github/ISSUE_TEMPLATE/feature_component.yml
@@ -30,8 +30,8 @@ body:
     attributes:
       label: 該当するfigmaファイルのURL
       description: 該当するfigmaファイルのURLを記述してください
-      default: https://www.figma.com/design/oeUBwjCgMezG78IXrMAv6O/BX
       placeholder: ex.https://www.figma.com/design/oeUBwjCgMezG78IXrMAv6O/BX
+      value: https://www.figma.com/design/oeUBwjCgMezG78IXrMAv6O/BX
     validations:
       required: true
 


### PR DESCRIPTION
>There is a problem with this template
body[3]: default is not a permitted attribute.


の修正対応。