### PR TITLE
feat: base card

### DIFF
--- a/app/components/BaseCard/BaseCard.browser.test.tsx
+++ b/app/components/BaseCard/BaseCard.browser.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { render } from "../../../test/test-react";
+import { BaseCard } from "./BaseCard";
+
+describe("BaseCard", () => {
+  it("renders title and body correctly", () => {
+    const screen = render(
+      <BaseCard body={<div>Body Content</div>} title="Card Title" />,
+    );
+    expect(screen.getByText("Card Title")).toBeTruthy();
+    expect(screen.getByText("Body Content")).toBeTruthy();
+  });
+
+  it("applies default black background color to title", () => {
+    const { container } = render(
+      <BaseCard body={<div>Body</div>} title="Title" />,
+    );
+    const titleWrapper = container.querySelector(".bg-black");
+    expect(titleWrapper).not.toBeNull();
+    expect(titleWrapper?.classList.contains("bg-black")).toBe(true);
+  });
+
+  it("applies custom background color to title", () => {
+    const { container } = render(
+      <BaseCard
+        body={<div>Body</div>}
+        title="Title"
+        titleBgColor="bg-primary"
+      />,
+    );
+    const titleWrapper = container.querySelector(".bg-primary");
+    expect(titleWrapper).not.toBeNull();
+    expect(titleWrapper?.classList.contains("bg-primary")).toBe(true);
+  });
+
+  it("applies custom className to container", () => {
+    const { container } = render(
+      <BaseCard
+        body={<div>Body</div>}
+        className="custom-class"
+        title="Title"
+      />,
+    );
+    expect(container.firstChild).toBeTruthy();
+    const element = container.firstChild as HTMLElement;
+    expect(element.className).toContain("custom-class");
+  });
+
+  it("renders complex ReactNode as title and body", () => {
+    const screen = render(
+      <BaseCard
+        body={
+          <div>
+            <p>Paragraph 1</p>
+            <p>Paragraph 2</p>
+          </div>
+        }
+        title={
+          <div>
+            <span>Complex</span> <span>Title</span>
+          </div>
+        }
+      />,
+    );
+    expect(screen.getByText("Complex")).toBeTruthy();
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("Paragraph 1")).toBeTruthy();
+    expect(screen.getByText("Paragraph 2")).toBeTruthy();
+  });
+});

--- a/app/components/BaseCard/BaseCard.tsx
+++ b/app/components/BaseCard/BaseCard.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+type BaseCardProps = {
+  title: ReactNode;
+  body: ReactNode;
+  titleBgColor?: string;
+  className?: string;
+};
+
+export function BaseCard({
+  title,
+  body,
+  titleBgColor = "bg-black",
+  className,
+}: BaseCardProps) {
+  return (
+    <div
+      className={`w-full overflow-hidden rounded-lg border border-gray-2 ${className ?? ""}`}
+    >
+      <div
+        className={`flex items-center justify-between px-4 py-3 ${titleBgColor}`}
+      >
+        <div>{title}</div>
+      </div>
+      <div className="bg-white p-5">{body}</div>
+    </div>
+  );
+}

--- a/app/components/BaseCard/index.ts
+++ b/app/components/BaseCard/index.ts
@@ -1,0 +1,2 @@
+export { BaseCard } from "./BaseCard";
+


### PR DESCRIPTION
## 概要
共通で使用できるカードコンポーネント `BaseCard` を作成しました。

Closes #215

## 変更内容

### 1. BaseCardコンポーネントの実装
`app/components/BaseCard/` ディレクトリ配下に以下のファイルを作成:

- **BaseCard.tsx** - メインコンポーネント
- **BaseCard.browser.test.tsx** - ブラウザテスト
- **index.ts** - エクスポート定義

#### 仕様
- **Props:**
  - `title: ReactNode` - カードのタイトル（必須）
  - `body: ReactNode` - カードのボディコンテンツ（必須）
  - `titleBgColor?: string` - タイトル部分の背景色（オプション、デフォルト: `"bg-black"`）
  - `className?: string` - カスタムクラス（オプション）

- **特徴:**
  - カード幅はデフォルトで100%
  - タイトル背景色をカスタマイズ可能
  - ReactNodeを受け取るため柔軟な使い方が可能
  - `app.css` で定義されたデザインシステムに準拠

#### 使用例
```
// シンプルな使い方
<BaseCard 
  title="カードタイトル" 
  body={<p>カードの内容</p>} 
/>
```

```
// カスタム背景色を指定
<BaseCard 
  title="重要なお知らせ"
  body={<div>内容</div>}
  titleBgColor="bg-primary"
/>
```
### 2. テストの追加
以下のテストケースを実装:
- タイトルとボディが正しくレンダリングされること
- デフォルトの黒背景が適用されること
- カスタム背景色が正しく適用されること
- カスタムクラス名が適用されること
- 複雑なReactNodeを正しくレンダリングできること

## テスト結果
- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [ ] `pnpm run test` が成功すること（該当する場合）
- [x] `pnpm run build` が成功すること
