### PR TITLE
feat: ポストの影響力グラフカード・コミュニティーノートの評価状況グラフカードの作成

### DIFF
--- a/app/components/notes-evaluation-status-chart/NotesEvaluationStatusChart.tsx
+++ b/app/components/notes-evaluation-status-chart/NotesEvaluationStatusChart.tsx
@@ -1,0 +1,143 @@
+import { Stack } from "@mantine/core";
+import * as React from "react";
+
+import {
+  type CategoryConfig,
+  GraphContainer,
+  GraphSizeLegend,
+  GraphStatusFilter,
+  GraphWrapper,
+  ScatterBubbleChart,
+  STATUS_COLORS,
+  type StatusValue,
+} from "~/components/graph";
+import type { ScatterDataItem } from "~/components/graph/ScatterBubbleChart";
+
+import { generateMockData } from "./data";
+
+/**
+ * ノート評価状況のカテゴリ設定
+ * 凡例の表示順序: 公開中 → 評価中 → 非公開
+ */
+const NOTE_STATUS_CATEGORIES: CategoryConfig[] = [
+  { key: "published", name: "公開中", color: STATUS_COLORS.evaluating },
+  { key: "evaluating", name: "評価中", color: STATUS_COLORS.published },
+  { key: "unpublished", name: "非公開", color: STATUS_COLORS.temporarilyPublished },
+];
+
+/** ノート評価状況データの型 */
+export type NoteEvaluationStatusData = {
+  noteId: string;
+  name: string;
+  notHelpful: number;
+  helpful: number;
+  impressions: number;
+  /** ステータス: published=公開中, evaluating=評価中, unpublished=非公開 */
+  status: "published" | "evaluating" | "unpublished";
+};
+
+export type NotesEvaluationStatusChartProps = {
+  data?: NoteEvaluationStatusData[];
+  /** 更新日（例: "2025年10月13日更新"） */
+  updatedAt?: string;
+};
+
+/**
+ * コミュニティーノートの評価状況グラフカード
+ * X軸: 「役に立たなかった」の評価数、Y軸: 「役に立った」の評価数、バブルサイズ: インプレッション
+ */
+export const NotesEvaluationStatusChart = ({
+  data,
+  updatedAt = "2025年10月13日更新",
+}: NotesEvaluationStatusChartProps) => {
+  const [status, setStatus] = React.useState<StatusValue>("all");
+
+  const rawData = React.useMemo(() => data ?? generateMockData(), [data]);
+
+  const axisRange = React.useMemo(() => {
+    const notHelpfulValues = rawData.map((d) => d.notHelpful);
+    const helpfulValues = rawData.map((d) => d.helpful);
+    return {
+      xMax: Math.max(...notHelpfulValues),
+      yMax: Math.max(...helpfulValues),
+    };
+  }, [rawData]);
+
+  const impressionRange = React.useMemo(() => {
+    const impressions = rawData.map((d) => d.impressions);
+    return {
+      min: Math.min(...impressions),
+      max: Math.max(...impressions),
+    };
+  }, [rawData]);
+
+  const filteredData = React.useMemo(() => {
+    if (status === "all") return rawData;
+    return rawData.filter((d) => d.status === status);
+  }, [rawData, status]);
+
+  const chartData: ScatterDataItem[] = React.useMemo(() => {
+    return filteredData.map((d) => ({
+      x: d.notHelpful,
+      y: d.helpful,
+      size: d.impressions,
+      name: d.name,
+      category: d.status,
+    }));
+  }, [filteredData]);
+
+  const tooltipFormatter = React.useCallback((item: ScatterDataItem): string => {
+    const statusNames: Record<string, string> = {
+      published: "公開中",
+      evaluating: "評価中",
+      unpublished: "非公開",
+    };
+    return `<strong>${item.name}</strong><br/>
+      「役に立たなかった」の評価数: ${item.x.toLocaleString()}<br/>
+      「役に立った」の評価数: ${item.y.toLocaleString()}<br/>
+      インプレッション: ${item.size.toLocaleString()}<br/>
+      ステータス: ${statusNames[item.category as string] ?? item.category}`;
+  }, []);
+
+  const statusOptions = [
+    { value: "all" as const, label: "全て" },
+    { value: "published" as const, label: "公開中" },
+    { value: "evaluating" as const, label: "評価中" },
+    { value: "unpublished" as const, label: "非公開" },
+  ];
+
+  const footer = (
+    <Stack gap="md">
+      <GraphStatusFilter onChange={setStatus} statuses={statusOptions} value={status} />
+      <GraphSizeLegend
+        label="インプレッション"
+        max={impressionRange.max}
+        maxBubbleSize={28}
+        min={impressionRange.min}
+        minBubbleSize={6}
+      />
+    </Stack>
+  );
+
+  return (
+    <GraphWrapper
+      hidePeriodSelector
+      title="コミュニティーノートの評価状況"
+      updatedAt={updatedAt}
+    >
+      <GraphContainer footer={footer}>
+        <ScatterBubbleChart
+          categories={NOTE_STATUS_CATEGORIES}
+          data={chartData}
+          height="60vh"
+          minHeight={400}
+          tooltipFormatter={tooltipFormatter}
+          xAxisMax={axisRange.xMax}
+          xAxisName="「役に立たなかった」の評価数"
+          yAxisMax={axisRange.yMax}
+          yAxisName="「役に立った」の評価数"
+        />
+      </GraphContainer>
+    </GraphWrapper>
+  );
+};

--- a/app/components/notes-evaluation-status-chart/data.ts
+++ b/app/components/notes-evaluation-status-chart/data.ts
@@ -1,0 +1,84 @@
+import type { NoteEvaluationStatusData } from "./NotesEvaluationStatusChart";
+
+/**
+ * コミュニティーノートの評価状況グラフ用モックデータを生成
+ * 元デザイン参考:
+ * - 公開中（青）: 左上に集中（helpfulが高く、notHelpfulが低い）
+ * - 評価中（紫）: 左下〜中央に広く散らばる
+ * - 非公開（ピンク）: 右下付近（notHelpfulが高い）
+ */
+export const generateMockData = (): NoteEvaluationStatusData[] => {
+  const result: NoteEvaluationStatusData[] = [];
+
+  // 公開中（青/シアン）- 左上に集中、helpfulが高くnotHelpfulが低い
+  for (let i = 0; i < 25; i++) {
+    result.push({
+      noteId: `published-${i + 1}`,
+      name: `公開中ノート${i + 1}`,
+      notHelpful: Math.floor(Math.random() * 120) + 20,
+      helpful: Math.floor(Math.random() * 800) + 1000,
+      impressions: Math.floor(Math.random() * 50000000) + 20000000,
+      status: "published",
+    });
+  }
+  // 公開中で特に上部にあるもの
+  for (let i = 0; i < 8; i++) {
+    result.push({
+      noteId: `published-top-${i + 1}`,
+      name: `公開中ノート${26 + i}`,
+      notHelpful: Math.floor(Math.random() * 80) + 30,
+      helpful: Math.floor(Math.random() * 300) + 1700,
+      impressions: Math.floor(Math.random() * 40000000) + 30000000,
+      status: "published",
+    });
+  }
+
+  // 評価中（紫）- 左下〜中央に広く散らばる
+  // 左下に密集するグループ
+  for (let i = 0; i < 40; i++) {
+    result.push({
+      noteId: `evaluating-dense-${i + 1}`,
+      name: `評価中ノート${i + 1}`,
+      notHelpful: Math.floor(Math.random() * 150) + 20,
+      helpful: Math.floor(Math.random() * 600) + 100,
+      impressions: Math.floor(Math.random() * 40000000) + 5000000,
+      status: "evaluating",
+    });
+  }
+  // 中央に散らばるグループ
+  for (let i = 0; i < 20; i++) {
+    result.push({
+      noteId: `evaluating-mid-${i + 1}`,
+      name: `評価中ノート${41 + i}`,
+      notHelpful: Math.floor(Math.random() * 100) + 80,
+      helpful: Math.floor(Math.random() * 500) + 800,
+      impressions: Math.floor(Math.random() * 50000000) + 10000000,
+      status: "evaluating",
+    });
+  }
+
+  // 非公開（ピンク）- 右側、notHelpfulが高い
+  for (let i = 0; i < 12; i++) {
+    result.push({
+      noteId: `unpublished-${i + 1}`,
+      name: `非公開ノート${i + 1}`,
+      notHelpful: Math.floor(Math.random() * 200) + 250,
+      helpful: Math.floor(Math.random() * 500) + 100,
+      impressions: Math.floor(Math.random() * 40000000) + 10000000,
+      status: "unpublished",
+    });
+  }
+  // 非公開で右下にあるもの
+  for (let i = 0; i < 5; i++) {
+    result.push({
+      noteId: `unpublished-right-${i + 1}`,
+      name: `非公開ノート${13 + i}`,
+      notHelpful: Math.floor(Math.random() * 100) + 400,
+      helpful: Math.floor(Math.random() * 300) + 50,
+      impressions: Math.floor(Math.random() * 30000000) + 15000000,
+      status: "unpublished",
+    });
+  }
+
+  return result;
+};

--- a/app/components/notes-evaluation-status-chart/index.ts
+++ b/app/components/notes-evaluation-status-chart/index.ts
@@ -1,0 +1,5 @@
+export { NotesEvaluationStatusChart } from "./NotesEvaluationStatusChart";
+export type {
+  NoteEvaluationStatusData,
+  NotesEvaluationStatusChartProps,
+} from "./NotesEvaluationStatusChart";

--- a/app/components/post-influence-chart/PostInfluenceChart.tsx
+++ b/app/components/post-influence-chart/PostInfluenceChart.tsx
@@ -1,0 +1,143 @@
+import { Stack } from "@mantine/core";
+import * as React from "react";
+
+import {
+  type CategoryConfig,
+  GraphContainer,
+  GraphSizeLegend,
+  GraphStatusFilter,
+  GraphWrapper,
+  ScatterBubbleChart,
+  STATUS_COLORS,
+  type StatusValue,
+} from "~/components/graph";
+import type { ScatterDataItem } from "~/components/graph/ScatterBubbleChart";
+
+import { generateMockData } from "./data";
+
+/**
+ * ポスト影響力のカテゴリ設定
+ * 凡例の表示順序: 公開中 → 評価中 → 非公開
+ */
+const POST_STATUS_CATEGORIES: CategoryConfig[] = [
+  { key: "published", name: "公開中", color: STATUS_COLORS.evaluating },
+  { key: "evaluating", name: "評価中", color: STATUS_COLORS.published },
+  { key: "unpublished", name: "非公開", color: STATUS_COLORS.temporarilyPublished },
+];
+
+/** ポスト影響力データの型 */
+export type PostInfluenceData = {
+  postId: string;
+  name: string;
+  reposts: number;
+  likes: number;
+  impressions: number;
+  /** ステータス: published=公開中, evaluating=評価中, unpublished=非公開 */
+  status: "published" | "evaluating" | "unpublished";
+};
+
+export type PostInfluenceChartProps = {
+  data?: PostInfluenceData[];
+  /** 更新日（例: "2025年10月13日更新"） */
+  updatedAt?: string;
+};
+
+/**
+ * ポストの影響力グラフカード
+ * X軸: リポスト数、Y軸: いいね数、バブルサイズ: インプレッション
+ */
+export const PostInfluenceChart = ({
+  data,
+  updatedAt = "2025年10月13日更新",
+}: PostInfluenceChartProps) => {
+  const [status, setStatus] = React.useState<StatusValue>("all");
+
+  const rawData = React.useMemo(() => data ?? generateMockData(), [data]);
+
+  const axisRange = React.useMemo(() => {
+    const repostValues = rawData.map((d) => d.reposts);
+    const likeValues = rawData.map((d) => d.likes);
+    return {
+      xMax: Math.max(...repostValues),
+      yMax: Math.max(...likeValues),
+    };
+  }, [rawData]);
+
+  const impressionRange = React.useMemo(() => {
+    const impressions = rawData.map((d) => d.impressions);
+    return {
+      min: Math.min(...impressions),
+      max: Math.max(...impressions),
+    };
+  }, [rawData]);
+
+  const filteredData = React.useMemo(() => {
+    if (status === "all") return rawData;
+    return rawData.filter((d) => d.status === status);
+  }, [rawData, status]);
+
+  const chartData: ScatterDataItem[] = React.useMemo(() => {
+    return filteredData.map((d) => ({
+      x: d.reposts,
+      y: d.likes,
+      size: d.impressions,
+      name: d.name,
+      category: d.status,
+    }));
+  }, [filteredData]);
+
+  const tooltipFormatter = React.useCallback((item: ScatterDataItem): string => {
+    const statusNames: Record<string, string> = {
+      published: "公開中",
+      evaluating: "評価中",
+      unpublished: "非公開",
+    };
+    return `<strong>${item.name}</strong><br/>
+      リポスト数: ${item.x.toLocaleString()}<br/>
+      いいね数: ${item.y.toLocaleString()}<br/>
+      インプレッション: ${item.size.toLocaleString()}<br/>
+      ステータス: ${statusNames[item.category as string] ?? item.category}`;
+  }, []);
+
+  const statusOptions = [
+    { value: "all" as const, label: "全て" },
+    { value: "published" as const, label: "公開中" },
+    { value: "evaluating" as const, label: "評価中" },
+    { value: "unpublished" as const, label: "非公開" },
+  ];
+
+  const footer = (
+    <Stack gap="md">
+      <GraphStatusFilter onChange={setStatus} statuses={statusOptions} value={status} />
+      <GraphSizeLegend
+        label="インプレッション"
+        max={impressionRange.max}
+        maxBubbleSize={28}
+        min={impressionRange.min}
+        minBubbleSize={6}
+      />
+    </Stack>
+  );
+
+  return (
+    <GraphWrapper
+      hidePeriodSelector
+      title="ポストの影響力"
+      updatedAt={updatedAt}
+    >
+      <GraphContainer footer={footer}>
+        <ScatterBubbleChart
+          categories={POST_STATUS_CATEGORIES}
+          data={chartData}
+          height="60vh"
+          minHeight={400}
+          tooltipFormatter={tooltipFormatter}
+          xAxisMax={axisRange.xMax}
+          xAxisName="リポスト数"
+          yAxisMax={axisRange.yMax}
+          yAxisName="いいね数"
+        />
+      </GraphContainer>
+    </GraphWrapper>
+  );
+};

--- a/app/components/post-influence-chart/data.ts
+++ b/app/components/post-influence-chart/data.ts
@@ -1,0 +1,107 @@
+import type { PostInfluenceData } from "./PostInfluenceChart";
+
+/**
+ * ポストの影響力グラフ用モックデータを生成
+ * 元デザイン参考:
+ * - 公開中（青）: 左下に密集、一部は評価中と重なるエリアに
+ * - 評価中（紫）: 対角線状に広がる分布、公開中・非公開と一部重なる
+ * - 非公開（ピンク）: 中央〜右上に点在、評価中と重なるエリアにも配置
+ */
+export const generateMockData = (): PostInfluenceData[] => {
+  const result: PostInfluenceData[] = [];
+
+  // 公開中（青/シアン）- 左下に集中、一部は評価中と重なるエリアに
+  for (let i = 0; i < 12; i++) {
+    result.push({
+      postId: `published-${i + 1}`,
+      name: `公開中ポスト${i + 1}`,
+      reposts: Math.floor(Math.random() * 3000) + 500,
+      likes: Math.floor(Math.random() * 20000) + 3000,
+      impressions: Math.floor(Math.random() * 5000000) + 500000,
+      status: "published",
+    });
+  }
+  // 公開中 - 評価中と重なるエリア（少し右上に）
+  for (let i = 0; i < 8; i++) {
+    result.push({
+      postId: `published-overlap-${i + 1}`,
+      name: `公開中ポスト${13 + i}`,
+      reposts: Math.floor(Math.random() * 5000) + 3000,
+      likes: Math.floor(Math.random() * 30000) + 20000,
+      impressions: Math.floor(Math.random() * 8000000) + 2000000,
+      status: "published",
+    });
+  }
+
+  // 評価中（紫）- 左下から対角線状に、公開中・非公開と一部重なる
+  // 左下グループ（公開中と重なるエリア）
+  for (let i = 0; i < 15; i++) {
+    result.push({
+      postId: `evaluating-left-${i + 1}`,
+      name: `評価中ポスト${i + 1}`,
+      reposts: Math.floor(Math.random() * 6000) + 2000,
+      likes: Math.floor(Math.random() * 40000) + 15000,
+      impressions: Math.floor(Math.random() * 25000000) + 10000000,
+      status: "evaluating",
+    });
+  }
+  // 中央グループ
+  for (let i = 0; i < 25; i++) {
+    result.push({
+      postId: `evaluating-mid-${i + 1}`,
+      name: `評価中ポスト${16 + i}`,
+      reposts: Math.floor(Math.random() * 15000) + 8000,
+      likes: Math.floor(Math.random() * 80000) + 40000,
+      impressions: Math.floor(Math.random() * 45000000) + 20000000,
+      status: "evaluating",
+    });
+  }
+  // 右上グループ（非公開と重なるエリア）
+  for (let i = 0; i < 15; i++) {
+    result.push({
+      postId: `evaluating-right-${i + 1}`,
+      name: `評価中ポスト${41 + i}`,
+      reposts: Math.floor(Math.random() * 20000) + 20000,
+      likes: Math.floor(Math.random() * 80000) + 100000,
+      impressions: Math.floor(Math.random() * 50000000) + 30000000,
+      status: "evaluating",
+    });
+  }
+  // 上部の大きめバブル
+  for (let i = 0; i < 5; i++) {
+    result.push({
+      postId: `evaluating-top-${i + 1}`,
+      name: `評価中ポスト${56 + i}`,
+      reposts: Math.floor(Math.random() * 15000) + 15000,
+      likes: Math.floor(Math.random() * 30000) + 180000,
+      impressions: Math.floor(Math.random() * 40000000) + 40000000,
+      status: "evaluating",
+    });
+  }
+
+  // 非公開（ピンク）- 評価中と重なるエリアにも配置
+  // 中央〜右上（評価中と重なる）
+  for (let i = 0; i < 6; i++) {
+    result.push({
+      postId: `unpublished-mid-${i + 1}`,
+      name: `非公開ポスト${i + 1}`,
+      reposts: Math.floor(Math.random() * 15000) + 15000,
+      likes: Math.floor(Math.random() * 60000) + 80000,
+      impressions: Math.floor(Math.random() * 35000000) + 20000000,
+      status: "unpublished",
+    });
+  }
+  // 右上
+  for (let i = 0; i < 4; i++) {
+    result.push({
+      postId: `unpublished-right-${i + 1}`,
+      name: `非公開ポスト${7 + i}`,
+      reposts: Math.floor(Math.random() * 15000) + 30000,
+      likes: Math.floor(Math.random() * 50000) + 150000,
+      impressions: Math.floor(Math.random() * 30000000) + 30000000,
+      status: "unpublished",
+    });
+  }
+
+  return result;
+};

--- a/app/components/post-influence-chart/index.ts
+++ b/app/components/post-influence-chart/index.ts
@@ -1,0 +1,2 @@
+export { PostInfluenceChart } from "./PostInfluenceChart";
+export type { PostInfluenceData, PostInfluenceChartProps } from "./PostInfluenceChart";

--- a/app/routes/test2.tsx
+++ b/app/routes/test2.tsx
@@ -4,22 +4,19 @@ import { DailyNotesCreationChart } from "~/components/daily-notes-creation-chart
 import { DailyPostCountChart } from "~/components/daily-post-count-chart";
 import { NotesAnnualChartSection } from "~/components/notes-annual-chart";
 import { NotesEvaluationChartSection } from "~/components/notes-evaluation-chart";
+import { NotesEvaluationStatusChart } from "~/components/notes-evaluation-status-chart";
+import { PostInfluenceChart } from "~/components/post-influence-chart";
 
 export default function Test2() {
   return (
     <Stack gap="xl" p="md">
       <Title order={2}>GraphWrapper デモ</Title>
 
-      {/* DailyNotesCreationChart デモ */}
+      <PostInfluenceChart />
+      <NotesEvaluationStatusChart />
       <DailyNotesCreationChart />
-
-      {/* DailyPostCountChart デモ */}
       <DailyPostCountChart />
-
-      {/* NotesAnnualChartSection デモ */}
       <NotesAnnualChartSection />
-
-      {/* NotesEvaluationChartSection デモ */}
       <NotesEvaluationChartSection />
     </Stack>
   );


### PR DESCRIPTION
#269 #270 の内容を含んでしまっているので、先にそちらのレビューをお願いします 🙏

## 概要

ポストの影響力とコミュニティーノートの評価状況を可視化するグラフカードコンポーネントを追加しました。

Closes #236
Closes #237

## 変更内容

### 1. PostInfluenceChart コンポーネントの追加 (#236)

- X軸: リポスト数、Y軸: いいね数、バブルサイズ: インプレッションで表現する散布図
- ステータスフィルター（全て/公開中/評価中/非公開）でのフィルタリング機能
- インプレッションのサイズ凡例を下部に表示
- モックデータ生成機能を含む
<img width="1216" height="923" alt="image" src="https://github.com/user-attachments/assets/9acff617-5eda-4c8d-b136-159df9a2324f" />


### 2. NotesEvaluationStatusChart コンポーネントの追加 (#237)

- X軸:「役に立たなかった」の評価数、Y軸:「役に立った」の評価数、バブルサイズ: インプレッションで表現する散布図
- ステータスフィルター（全て/公開中/評価中/非公開）でのフィルタリング機能
- インプレッションのサイズ凡例を下部に表示
- モックデータ生成機能を含む
<img width="1219" height="918" alt="image" src="https://github.com/user-attachments/assets/bdc75bb3-fff6-46f2-8977-eda06c3931fd" />


### 3. GraphSizeLegend の改善

- きれいなステップ間隔（1, 2, 5, 10の倍数）を計算する `getNiceStepSize` 関数を追加
- 最小値と最大値は実データの値を使用し、中間のステップのみきれいな数値で分割するよう改善

## 補足

- 色の割り当ては後で調整予定のため、現状のままとしています
- 期間セレクターは非表示（`hidePeriodSelector`）としています

## テスト結果

- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [x] `pnpm run build` が成功すること