### PR TITLE
feat: account ranking section

### DIFF
--- a/app/components/account-ranking/AccountRankingSection.browser.test.tsx
+++ b/app/components/account-ranking/AccountRankingSection.browser.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { AccountRankingSection } from "./AccountRankingSection";
+import type { AccountRankingData } from "./AccountRankingSection";
+
+const mockData: AccountRankingData[] = [
+  {
+    username: "test_user1",
+    displayName: "テストユーザー1",
+    noteCount: 544,
+    change: "+12",
+    worldRank: 4,
+    changeDirection: "up",
+  },
+  {
+    username: "test_user2",
+    displayName: "テストユーザー2",
+    noteCount: 521,
+    change: "+6",
+    worldRank: 5,
+    changeDirection: "up",
+  },
+  {
+    username: "test_user3",
+    displayName: "テストユーザー3",
+    noteCount: 500,
+    change: "-3",
+    worldRank: 6,
+    changeDirection: "down",
+  },
+];
+
+describe("AccountRankingSection", () => {
+  it("should render the component with title", () => {
+    render(<AccountRankingSection data={mockData} />);
+    expect(screen.getByText("アカウントランキング")).toBeInTheDocument();
+  });
+
+  it("should display table headers correctly", () => {
+    render(<AccountRankingSection data={mockData} />);
+    expect(screen.getByText("順位")).toBeInTheDocument();
+    expect(screen.getByText("ユーザー名")).toBeInTheDocument();
+    expect(screen.getByText("付与数")).toBeInTheDocument();
+    expect(screen.getByText("前回比")).toBeInTheDocument();
+    expect(screen.getByText("世界ランキング")).toBeInTheDocument();
+  });
+
+  it("should display ranking data in table rows", () => {
+    render(<AccountRankingSection data={mockData} />);
+    expect(screen.getByText("テストユーザー1")).toBeInTheDocument();
+    expect(screen.getByText("544")).toBeInTheDocument();
+    expect(screen.getByText("+12")).toBeInTheDocument();
+  });
+
+  it("should display rank numbers starting from 1", () => {
+    render(<AccountRankingSection data={mockData} />);
+    const table = screen.getByRole("table");
+    const rows = table.querySelectorAll("tbody tr");
+    
+    // Check first row has rank 1
+    expect(rows[0]).toHaveTextContent("1");
+    // Check second row has rank 2
+    expect(rows[1]).toHaveTextContent("2");
+    // Check third row has rank 3
+    expect(rows[2]).toHaveTextContent("3");
+  });
+
+  it("should render username as clickable link to Twitter", () => {
+    render(<AccountRankingSection data={mockData} />);
+    const link = screen.getByText("テストユーザー1");
+    expect(link).toHaveAttribute("href", "https://x.com/test_user1");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("should display updated date when provided", () => {
+    render(
+      <AccountRankingSection data={mockData} updatedAt="2025年10月13日更新" />
+    );
+    expect(screen.getByText("2025年10月13日更新")).toBeInTheDocument();
+  });
+
+  it("should handle period selection dropdown", async () => {
+    const user = userEvent.setup();
+    render(<AccountRankingSection data={mockData} />);
+    
+    // デフォルト値は「直近1ヶ月」
+    expect(screen.getByDisplayValue("直近1ヶ月")).toBeInTheDocument();
+  });
+
+  it("should limit display to 10 records", () => {
+    const largeData: AccountRankingData[] = Array.from(
+      { length: 20 },
+      (_, i) => ({
+        username: `user${i}`,
+        displayName: `ユーザー${i}`,
+        noteCount: 500 - i * 10,
+        change: "+5",
+        worldRank: i + 1,
+        changeDirection: "up" as const,
+      })
+    );
+
+    render(<AccountRankingSection data={largeData} />);
+    const table = screen.getByRole("table");
+    const rows = table.querySelectorAll("tbody tr");
+    
+    // Should only display first 10 rows
+    expect(rows).toHaveLength(10);
+  });
+
+  it("should apply correct color to change values", () => {
+    render(<AccountRankingSection data={mockData} />);
+    
+    // Positive change should be green
+    const positiveChange = screen.getByText("+12");
+    expect(positiveChange).toHaveClass("text-green");
+    
+    // Negative change should be red
+    const negativeChange = screen.getByText("-3");
+    expect(negativeChange).toHaveClass("text-red");
+  });
+});
+

--- a/app/components/account-ranking/AccountRankingSection.tsx
+++ b/app/components/account-ranking/AccountRankingSection.tsx
@@ -1,0 +1,144 @@
+import { Anchor, Table } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import * as React from "react";
+
+import { GraphContainer } from "~/components/graph/GraphContainer";
+import { GraphWrapper } from "~/components/graph/GraphWrapper";
+import { MOBILE_BREAKPOINT } from "~/constants/breakpoints";
+import { buildTwitterProfileUrl } from "~/feature/twitter/link-builder";
+
+import { generateMockData } from "./data";
+
+/** アカウントランキングデータの型 */
+export type AccountRankingData = {
+  username: string;
+  displayName: string;
+  noteCount: number;
+  change: string;
+  worldRank: number;
+  /** 前回比の変動（増加、減少、変化なし） */
+  changeDirection: "up" | "down" | "neutral";
+};
+
+export type AccountRankingSectionProps = {
+  data?: AccountRankingData[];
+  updatedAt?: string;
+  periodOptions?: Array<{ value: string; label: string }>;
+  initialPeriod?: string;
+};
+
+/**
+ * アカウントランキングセクション
+ * - ユーザー名、付与数、前回比、世界ランキングを表形式で表示
+ * - 名前をクリックでTwitterへ遷移
+ */
+export const AccountRankingSection = ({
+  data,
+  updatedAt = "2025年10月13日更新",
+  periodOptions,
+  initialPeriod = "1month",
+}: AccountRankingSectionProps) => {
+  const isMobile = useMediaQuery(MOBILE_BREAKPOINT) ?? false;
+  const [period, setPeriod] = React.useState(initialPeriod);
+
+  // TODO: 期間変更時にAPIからデータを取得するロジックを実装する
+  const rankingData = React.useMemo(
+    () => (data ?? generateMockData()).slice(0, 10),
+    [data],
+  );
+
+  const defaultPeriodOptions = React.useMemo(
+    () => [
+      { value: "1month", label: "直近1ヶ月" },
+      { value: "3months", label: "直近3ヶ月" },
+      { value: "6months", label: "直近6ヶ月" },
+      { value: "1year", label: "直近1年" },
+    ],
+    [],
+  );
+
+  const rows = rankingData.map((item, index) => (
+    <Table.Tr key={item.username}>
+      <Table.Td className="text-center text-white">{index + 1}</Table.Td>
+      <Table.Td>
+        <Anchor
+          className="!text-white !underline"
+          href={buildTwitterProfileUrl(item.username)}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {item.displayName}
+        </Anchor>
+      </Table.Td>
+      <Table.Td className="text-center text-white">
+        {item.noteCount.toLocaleString()}
+      </Table.Td>
+      <Table.Td className="text-center">
+        <span
+          className={
+            item.changeDirection === "up"
+              ? "text-green"
+              : item.changeDirection === "down"
+                ? "text-red"
+                : "text-white"
+          }
+        >
+          {item.change}
+        </span>
+      </Table.Td>
+      <Table.Td className="text-center text-white">{item.worldRank}</Table.Td>
+    </Table.Tr>
+  ));
+
+  return (
+    <GraphWrapper
+      onPeriodChange={setPeriod}
+      period={period}
+      periodOptions={periodOptions ?? defaultPeriodOptions}
+      title="アカウントランキング"
+    >
+      <GraphContainer>
+        <div className="w-full overflow-x-auto">
+          <Table
+            highlightOnHover
+            horizontalSpacing={isMobile ? "xs" : "md"}
+            striped="even"
+            stripedColor="var(--color-gray-1)"
+            styles={{
+              table: {
+                backgroundColor: "var(--color-black)",
+              },
+              th: {
+                backgroundColor: "var(--color-gray-1)",
+                borderBottom: "1px solid var(--color-gray-1)",
+                color: "white",
+                fontSize: isMobile ? "12px" : "14px",
+                fontWeight: 600,
+                textAlign: "center",
+              },
+              td: {
+                borderBottom: "1px solid var(--color-gray-1)",
+                color: "white",
+                fontSize: isMobile ? "12px" : "14px",
+              },
+            }}
+            verticalSpacing={isMobile ? "xs" : "sm"}
+          >
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th style={{ width: "10%" }}>順位</Table.Th>
+                <Table.Th style={{ textAlign: "left", width: "30%" }}>
+                  ユーザー名
+                </Table.Th>
+                <Table.Th style={{ width: "20%" }}>付与数</Table.Th>
+                <Table.Th style={{ width: "20%" }}>前回比</Table.Th>
+                <Table.Th style={{ width: "20%" }}>世界ランキング</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>{rows}</Table.Tbody>
+          </Table>
+        </div>
+      </GraphContainer>
+    </GraphWrapper>
+  );
+};

--- a/app/components/account-ranking/data.ts
+++ b/app/components/account-ranking/data.ts
@@ -1,0 +1,56 @@
+import type { AccountRankingData } from "./AccountRankingSection";
+
+/**
+ * アカウントランキング用モックデータを生成
+ */
+export const generateMockData = (): AccountRankingData[] => {
+  // サンプルとなる日本語ユーザー名のリスト
+  const sampleUsers = [
+    { username: "earthquake_japan", displayName: "麒麟地震研究所" },
+    { username: "breaking_news_jp", displayName: "ツイッター速報～Breaking News" },
+    { username: "news_daily_jp", displayName: "デイリーニュース速報" },
+    { username: "fact_check_jp", displayName: "ファクトチェックJP" },
+    { username: "science_news_jp", displayName: "サイエンスニュース" },
+    { username: "tech_updates_jp", displayName: "テックアップデート" },
+    { username: "politics_watch_jp", displayName: "政治ウォッチャー" },
+    { username: "weather_info_jp", displayName: "気象情報センター" },
+    { username: "sports_news_jp", displayName: "スポーツ速報" },
+    { username: "economy_today_jp", displayName: "経済トゥデイ" },
+    { username: "culture_news_jp", displayName: "カルチャーニュース" },
+    { username: "health_tips_jp", displayName: "健康情報局" },
+    { username: "edu_info_jp", displayName: "教育インフォメーション" },
+    { username: "travel_japan", displayName: "トラベルジャパン" },
+    { username: "food_news_jp", displayName: "フードニュース" },
+  ];
+
+  const result: AccountRankingData[] = [];
+
+  for (let i = 0; i < sampleUsers.length; i++) {
+    const user = sampleUsers[i];
+    
+    // 上位ほど付与数が多くなるように設定
+    const noteCount = Math.floor(Math.random() * 100) + (15 - i) * 50 + 300;
+    
+    // 前回比の変動値（-20 〜 +50の範囲でランダム）
+    const changeValue = Math.floor(Math.random() * 70) - 20;
+    const changeDirection: "up" | "down" | "neutral" =
+      changeValue > 0 ? "up" : changeValue < 0 ? "down" : "neutral";
+    const changeSign = changeValue > 0 ? "+" : changeValue === 0 ? "±" : "";
+    const change = changeValue === 0 ? "→" : `${changeSign}${changeValue}`;
+    
+    // 世界ランキング（上位ほど低い数値）
+    const worldRank = i + 1 + Math.floor(Math.random() * 3);
+
+    result.push({
+      username: user.username,
+      displayName: user.displayName,
+      noteCount,
+      change,
+      worldRank,
+      changeDirection,
+    });
+  }
+
+  return result;
+};
+

--- a/app/components/account-ranking/index.ts
+++ b/app/components/account-ranking/index.ts
@@ -1,0 +1,3 @@
+export { AccountRankingSection } from "./AccountRankingSection";
+export type { AccountRankingData, AccountRankingSectionProps } from "./AccountRankingSection";
+

--- a/app/feature/twitter/link-builder.ts
+++ b/app/feature/twitter/link-builder.ts
@@ -6,3 +6,9 @@ export const postLinkFromPostId = (postId: string): string => {
   // X redirects to correct post url regardless of userId, so just specify `i`
   return `https://x.com/i/status/${postId}`;
 };
+
+export const buildTwitterProfileUrl = (username: string): string => {
+  // Remove @ if present
+  const cleanUsername = username.startsWith("@") ? username.slice(1) : username;
+  return `https://x.com/${cleanUsername}`;
+};

--- a/app/routes/test2.tsx
+++ b/app/routes/test2.tsx
@@ -1,5 +1,6 @@
 import { Stack, Title } from "@mantine/core";
 
+import { AccountRankingSection } from "~/components/account-ranking";
 import { DailyNotesCreationChart } from "~/components/daily-notes-creation-chart";
 import { DailyPostCountChart } from "~/components/daily-post-count-chart";
 import { NotesAnnualChartSection } from "~/components/notes-annual-chart";
@@ -12,6 +13,7 @@ export default function Test2() {
     <Stack gap="xl" p="md">
       <Title order={2}>GraphWrapper デモ</Title>
 
+      <AccountRankingSection />
       <PostInfluenceChart />
       <NotesEvaluationStatusChart />
       <DailyNotesCreationChart />


### PR DESCRIPTION
## 概要

アカウントランキングセクションコンポーネントを新規作成しました。
コミュニティノート付与数に基づくユーザーランキングを表形式で表示し、期間選択やTwitterプロフィールへのリンク機能を実装しています。

Closes #228

## 変更内容

### 1. AccountRankingSectionコンポーネントの作成

- **新規ファイル**:
  - `app/components/account-ranking/AccountRankingSection.tsx` - メインコンポーネント
  - `app/components/account-ranking/data.ts` - モックデータ生成関数
  - `app/components/account-ranking/index.ts` - エクスポート
  - `app/components/account-ranking/AccountRankingSection.browser.test.tsx` - ブラウザテスト

- **機能**:
  - GraphWrapper/GraphContainerを使用した統一デザイン
  - Mantineの`Table`コンポーネントでランキング表示
  - 10件のレコード表示（上位10名）
  - カラム: 順位、ユーザー名、付与数、前回比、世界ランキング
  - ユーザー名クリックでTwitterプロフィールへ遷移
  - 期間選択機能（直近1ヶ月/3ヶ月/6ヶ月/1年）
  - 前回比の増減を色分け表示（増加=緑、減少=赤、変化なし=白）
  - レスポンシブ対応（モバイル/デスクトップ）

### 2. Twitter link-builderの拡張

- `app/feature/twitter/link-builder.ts`に`buildTwitterProfileUrl`関数を追加
- Twitterプロフィールページへのリンクを生成

### 3. テストページへの追加

- `app/routes/test2.tsx`にAccountRankingSectionを追加して動作確認可能に

### 4. スタイリング

- `app.css`で定義されている色変数（`--color-gray-1`, `--color-gray-2`, `--color-black`）を使用
- ストライプ効果でテーブルの視認性を向上
- プロジェクト全体のデザインガイドラインに準拠

## 補足

- 現在はモックデータを使用しています。実際のAPIエンドポイントが利用可能になったら、データ取得ロジックを実装する必要があります
- 期間選択時のデータ再取得ロジックは`TODO`コメントで明示
- Mantineのテーブルコンポーネントを使用し、`striped`や`highlightOnHover`などの組み込み機能を活用

## 効果

- ユーザーがコミュニティノート付与数のランキングを一目で把握できる
- Twitterプロフィールへの直接遷移により、ユーザー情報の確認が容易
- 期間選択機能により、異なる時間軸でのランキング変動を追跡可能
- 既存のGraphWrapper/GraphContainerパターンを使用し、UIの一貫性を保持

## テスト結果

- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [x] `pnpm run test` が成功すること（該当する場合）
- [x] `pnpm run build` が成功すること