### PR TITLE
feat: report card section

### DIFF
--- a/app/components/report-card-section/ReportCardSection.tsx
+++ b/app/components/report-card-section/ReportCardSection.tsx
@@ -1,0 +1,71 @@
+import { ReportIcon } from "~/components/icons";
+import { PageTitle } from "~/components/PageTitle";
+import { ReportCard } from "~/components/report-card/ReportCard";
+import { WEB_PATHS } from "~/constants/paths";
+
+export type ReportCardSectionProps = {
+  className?: string;
+};
+
+type ReportItem = {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+};
+
+const reportItems: ReportItem[] = [
+  {
+    id: "1",
+    title: "2025年 9月レポート",
+    description:
+      "奈良市の持続可能な発展を目指す意見が多岐にわたって集まっています。都市開発や交通インフラの革新、地域活性化、教育と地域社会の連携、観光振興、地域資源の活用、市民参加とAI活用による市政改革、高齢化社会への対応、防災力強化、環境保全、医療・教育の連携強化...",
+    href: "https://www.google.com",
+  },
+  {
+    id: "2",
+    title: "2025年 8月レポート",
+    description:
+      "奈良市の持続可能な発展を目指した様々な提案が集まりました。インフラ整備、地域社会の活性化、観光資源の保護、市民参加によるまちづくり、デジタル技術活用、防災対策、医療・教育分野での協力強化などがあげられています...",
+    href: "https://www.google.com",
+  },
+  {
+    id: "3",
+    title: "2025年 7月レポート",
+    description:
+      "奈良市において持続的な成長を実現するための意見が幅広く提出されました。交通網の整備、地域経済の活性化、観光の促進、環境対応、AIやICTの活用による行政効率化が注目されています...",
+    href: "https://www.google.com",
+  },
+  {
+    id: "4",
+    title: "2025年 6月レポート",
+    description:
+      "持続可能な奈良市の未来にむけたアイディアが集まりました。都市づくりの新戦略、若者や高齢者が活躍できる街づくり、災害対策の強化、観光振興策、市民との協働体制強化などが挙げられています...",
+    href: "https://www.google.com",
+  },
+];
+
+export const ReportCardSection = ({ className }: ReportCardSectionProps) => {
+  return (
+    <section className={className}>
+      <div className="flex items-center justify-between gap-4">
+        <PageTitle
+          icon={<ReportIcon isActive />}
+          subtitle="月次レポート"
+          title="Report"
+        />
+        <a
+          className="inline-flex items-center gap-2 text-primary hover:underline"
+          href={WEB_PATHS.report.index}
+        >
+          <span>View All</span>
+        </a>
+      </div>
+      <div className="grid grid-cols-1 gap-8 p-4 md:grid-cols-2 md:p-6 lg:grid-cols-4">
+        {reportItems.map((item) => (
+          <ReportCard item={item} key={item.id} />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/app/components/report-card/ReportCard.tsx
+++ b/app/components/report-card/ReportCard.tsx
@@ -1,0 +1,32 @@
+import { BaseCard } from "~/components/BaseCard/BaseCard";
+import { PlayButtonIcon } from "~/components/icons";
+
+export type ReportCardProps = {
+  item: ReportItem;
+};
+
+type ReportItem = {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+};
+
+export const ReportCard = ({ item }: ReportCardProps) => {
+  return (
+    <BaseCard
+      body={
+        <p className="text-body-l line-clamp-6 text-gray-3">
+          {item.description}
+        </p>
+      }
+      key={item.href}
+      title={
+        <span className="flex items-center gap-2 p-2 text-white hover:underline">
+          <PlayButtonIcon className="shrink-0" isActive />
+          <span className="text-heading-l">{item.title}</span>
+        </span>
+      }
+    />
+  );
+};

--- a/app/components/report-card/index.ts
+++ b/app/components/report-card/index.ts
@@ -1,0 +1,2 @@
+export { ReportCard } from "./ReportCard";
+export type { ReportCardProps } from "./ReportCard";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { Container, Stack } from "@mantine/core";
 
 import { AboutSection } from "~/components/about-section";
 import { FeatureSection } from "~/components/feature-section";
+import { ReportCardSection } from "~/components/report-card-section/ReportCardSection";
 
 import type { Route } from "./+types/_index";
 
@@ -17,6 +18,7 @@ export default function Index({}: Route.ComponentProps) {
         <Stack gap="xl">
           <AboutSection />
           <FeatureSection />
+          <ReportCardSection />
         </Stack>
       </Container>
     </main>


### PR DESCRIPTION
## 概要

月次レポートを表示するための `ReportCard` コンポーネントと `ReportCardSection` コンポーネントを新規作成しました。

## 変更内容

### 1. `ReportCard` コンポーネントの作成

`app/components/report-card/` ディレクトリを作成し、個別のレポートカードを表示するコンポーネントを実装しました。

- `BaseCard` コンポーネントをベースに作成
- `PlayButtonIcon` を使用したタイトル表示
- `app.css` で定義されたカラー（`text-gray-3`, `text-heading-l` など）を使用
- レポートのタイトルと説明文を表示

### 2. `ReportCardSection` コンポーネントの作成

`app/components/report-card-section/` ディレクトリを作成し、レポートカード一覧を表示するセクションコンポーネントを実装しました。

- `FeatureSection` の構造を参考に作成
- `PageTitle` と `ReportIcon` を使用したセクションタイトル
- View All リンクでレポート一覧ページへ遷移可能
- レスポンシブ対応のグリッドレイアウト（1列〜4列）

## 補足

- `FeatureSection.tsx` のコード構造を参考に実装
- カラーは既存の `app.css` で定義されているテーマカラーを使用

## 効果

- トップページに月次レポートセクションを追加できるようになりました
- 既存のデザインシステムに沿った一貫性のあるUIを提供

## テスト結果

- [ ] `pnpm run lint` が成功すること
- [ ] `pnpm run typecheck` が成功すること
- [ ] `pnpm run test` が成功すること（該当する場合）
- [ ] `pnpm run build` が成功すること