### PR TITLE
Fix/report card props

### DIFF
--- a/app/components/graph/GraphWrapper.tsx
+++ b/app/components/graph/GraphWrapper.tsx
@@ -1,4 +1,12 @@
-import { ActionIcon, Box, Group, Select, Stack, Text, Tooltip } from "@mantine/core";
+import {
+  ActionIcon,
+  Box,
+  Group,
+  Select,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 
 import { MOBILE_BREAKPOINT } from "~/constants/breakpoints";

--- a/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
+++ b/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
@@ -160,19 +160,22 @@ export const NotesEvaluationChartSection = ({
     }));
   }, [filteredData]);
 
-  const tooltipFormatter = React.useCallback((item: ScatterDataItem): string => {
-    const statusNames: Record<number, string> = {
-      0: "非公開",
-      1: "評価中",
-      2: "公開済",
-      3: "一時公開",
-    };
-    return `<strong>${item.name}</strong><br/>
+  const tooltipFormatter = React.useCallback(
+    (item: ScatterDataItem): string => {
+      const statusNames: Record<number, string> = {
+        0: "非公開",
+        1: "評価中",
+        2: "公開済",
+        3: "一時公開",
+      };
+      return `<strong>${item.name}</strong><br/>
       「役に立った」の評価数: ${item.x.toLocaleString()}<br/>
       「役に立たなかった」の評価数: ${item.y.toLocaleString()}<br/>
       インプレッション: ${item.size.toLocaleString()}<br/>
       ステータス: ${statusNames[item.category as number] ?? item.category}`;
-  }, []);
+    },
+    [],
+  );
 
   const footer = <GraphStatusFilter onChange={setStatus} value={status} />;
 
@@ -201,4 +204,3 @@ export const NotesEvaluationChartSection = ({
     </GraphWrapper>
   );
 };
-

--- a/app/components/report-card-section/ReportCardSection.tsx
+++ b/app/components/report-card-section/ReportCardSection.tsx
@@ -20,28 +20,28 @@ const reportItems: ReportItem[] = [
     title: "2025年 9月レポート",
     description:
       "奈良市の持続可能な発展を目指す意見が多岐にわたって集まっています。都市開発や交通インフラの革新、地域活性化、教育と地域社会の連携、観光振興、地域資源の活用、市民参加とAI活用による市政改革、高齢化社会への対応、防災力強化、環境保全、医療・教育の連携強化...",
-    href: "https://www.google.com",
+    href: WEB_PATHS.report.show.replace(":id", "1"),
   },
   {
     id: "2",
     title: "2025年 8月レポート",
     description:
       "奈良市の持続可能な発展を目指した様々な提案が集まりました。インフラ整備、地域社会の活性化、観光資源の保護、市民参加によるまちづくり、デジタル技術活用、防災対策、医療・教育分野での協力強化などがあげられています...",
-    href: "https://www.google.com",
+    href: WEB_PATHS.report.show.replace(":id", "2"),
   },
   {
     id: "3",
     title: "2025年 7月レポート",
     description:
       "奈良市において持続的な成長を実現するための意見が幅広く提出されました。交通網の整備、地域経済の活性化、観光の促進、環境対応、AIやICTの活用による行政効率化が注目されています...",
-    href: "https://www.google.com",
+    href: WEB_PATHS.report.show.replace(":id", "3"),
   },
   {
     id: "4",
     title: "2025年 6月レポート",
     description:
       "持続可能な奈良市の未来にむけたアイディアが集まりました。都市づくりの新戦略、若者や高齢者が活躍できる街づくり、災害対策の強化、観光振興策、市民との協働体制強化などが挙げられています...",
-    href: "https://www.google.com",
+    href: WEB_PATHS.report.show.replace(":id", "4"),
   },
 ];
 

--- a/app/components/report-card/ReportCard.tsx
+++ b/app/components/report-card/ReportCard.tsx
@@ -16,13 +16,15 @@ export const ReportCard = ({ item }: ReportCardProps) => {
   return (
     <BaseCard
       body={
-        <p className="text-body-l line-clamp-6 text-gray-3">
-          {item.description}
-        </p>
+        <a href={item.href}>
+          <p className="text-body-l line-clamp-6 text-gray-3 hover:underline">
+            {item.description}
+          </p>
+        </a>
       }
       key={item.href}
       title={
-        <span className="flex items-center gap-2 p-2 text-white hover:underline">
+        <span className="flex items-center gap-2 p-2 text-white">
           <PlayButtonIcon className="shrink-0" isActive />
           <span className="text-heading-l">{item.title}</span>
         </span>

--- a/app/constants/paths.ts
+++ b/app/constants/paths.ts
@@ -6,9 +6,11 @@ export const WEB_PATHS = {
   },
   feature: {
     index: "/feature",
+    show: "/feature/:id",
   },
   report: {
     index: "/report",
+    show: "/report/:id",
   },
   search: {
     index: "/search",


### PR DESCRIPTION
## 概要
ReportCard コンポーネントの本文をクリック可能にする

## 変更内容

### 1. ReportCard の本文リンク化

  - `body` 内の description を `<a>` タグで囲み、カードの本文部分をクリックすると該当ページへ遷移するように変更
  - ホバー時に underline が表示されるスタイルを追加
  - title 部分の `hover:underline` を削除

  **変更ファイル:** `app/components/report-card/ReportCard.tsx`

  ## 補足

  - HTML 仕様上、`<a>` タグ内に `<p>` タグをネストすることは問題なし
  - FeatureSection の BaseCard は body 内に既にリンクが含まれているため、今回の対象外

  ## 効果

  - ユーザーが ReportCard の本文をクリックして詳細ページへ遷移できるようになる
  - UX の向上

  ## テスト結果

  - [x] `pnpm run lint` が成功すること
  - [x] `pnpm run typecheck` が成功すること
  - [x] `pnpm run test` が成功すること（該当する場合）
  - [x] `pnpm run build` が成功すること
