### PR TITLE
feat: report summary card

### DIFF
--- a/app/components/report-summary-card/ReportSummaryCard.tsx
+++ b/app/components/report-summary-card/ReportSummaryCard.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@mantine/core";
+
+import { GraphContainer } from "~/components/graph/GraphContainer";
+import { GraphWrapper } from "~/components/graph/GraphWrapper";
+
+export type ReportSummaryCardProps = {
+  className?: string;
+  description: string;
+  href: string;
+  updatedAt: string;
+  title?: string;
+};
+
+export const ReportSummaryCard = ({
+  className,
+  description,
+  href,
+  updatedAt,
+  title = "レポート",
+}: ReportSummaryCardProps) => {
+  return (
+    <GraphWrapper
+      className={className}
+      hidePeriodSelector
+      title={title}
+      updatedAt={updatedAt}
+    >
+      <GraphContainer
+        footer={
+          <div className="flex justify-end">
+            <Button
+              className="!text-body-l"
+              component="a"
+              href={href}
+              radius="md"
+              variant="outline"
+            >
+              レポートの詳細を見る
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-body-l line-clamp-8 whitespace-pre-wrap text-white">
+          {description}
+        </p>
+      </GraphContainer>
+    </GraphWrapper>
+  );
+};

--- a/app/components/report-summary-card/index.ts
+++ b/app/components/report-summary-card/index.ts
@@ -1,0 +1,2 @@
+export { ReportSummaryCard } from "./ReportSummaryCard";
+export type { ReportSummaryCardProps } from "./ReportSummaryCard";


### PR DESCRIPTION
## 概要

レポートサマリーカードコンポーネントの作成

Closes #233

## 変更内容

### 1. ReportSummaryCardコンポーネントの作成

- `app/components/report-summary-card/ReportSummaryCard.tsx` を新規作成
  - `GraphWrapper` と `GraphContainer` を使用したレイアウト実装
  - レポートのタイトル、説明文、更新日時を表示
  - フッターに「レポートの詳細を見る」ボタンを配置
  - 説明文は8行まで表示し、それ以降は `line-clamp-8` で省略
  - `whitespace-pre-wrap` で改行を保持

### 2. エクスポートファイルの作成

- `app/components/report-summary-card/index.ts` を新規作成
  - `ReportSummaryCard` コンポーネントと `ReportSummaryCardProps` 型をエクスポート

## 補足

- `GraphWrapper` の `hidePeriodSelector` プロパティを使用して、期間選択器を非表示にしています
- タイトルのデフォルト値は「レポート」となっており、任意でカスタマイズ可能です
- 説明文は `text-body-l` クラスを使用し、既存のデザインシステムに準拠しています
- ボタンは Mantine UI の `Button` コンポーネントを使用し、`component="a"` でリンクとして動作します

## 効果

- レポートの概要を統一されたデザインで表示できるようになりました
- `GraphWrapper` を活用することで、既存のコンポーネントとの一貫性が保たれます
- レポート詳細ページへの導線が明確になり、ユーザビリティが向上します
- 再利用可能なコンポーネントとして、他のページでも利用可能です

## テスト結果

- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [x] `pnpm run test` が成功すること（該当する場合）
- [x] `pnpm run build` が成功すること


