### PR TITLE
feat: 検索結果の総件数を表示する (#295)

### DIFF
--- a/app/feature/search/components/SearchPagination.tsx
+++ b/app/feature/search/components/SearchPagination.tsx
@@ -69,6 +69,7 @@ export const SearchPagination = ({
     <Group {...groupProps}>
       <Text c="white">
         {pageFirstItemIndex} ～ {totalDisplayedItems} 件目を表示中
+        {meta.total != null && `（全 ${meta.total} 件）`}
       </Text>
       {prevTo ? (
         <ActionIcon

--- a/app/generated/api/client.msw.ts
+++ b/app/generated/api/client.msw.ts
@@ -143,6 +143,10 @@ export const getGetNotesApiV1DataNotesGetResponseMock = (
       faker.helpers.arrayElement([faker.internet.url(), null]),
       undefined,
     ]),
+    total: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
   },
   ...overrideResponse,
 });
@@ -202,6 +206,10 @@ export const getGetPostsApiV1DataPostsGetResponseMock = (
     ]),
     prev: faker.helpers.arrayElement([
       faker.helpers.arrayElement([faker.internet.url(), null]),
+      undefined,
+    ]),
+    total: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
       undefined,
     ]),
   },
@@ -307,6 +315,10 @@ export const getSearchApiV1DataSearchGetResponseMock = (
     ]),
     prev: faker.helpers.arrayElement([
       faker.helpers.arrayElement([faker.internet.url(), null]),
+      undefined,
+    ]),
+    total: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
       undefined,
     ]),
   },

--- a/app/generated/api/schemas/paginationMeta.ts
+++ b/app/generated/api/schemas/paginationMeta.ts
@@ -12,4 +12,6 @@ export interface PaginationMeta {
   next?: PaginationMetaNext;
   /** 前のページのリクエスト用 URL */
   prev?: PaginationMetaPrev;
+  /** 検索結果の総件数 */
+  total?: number;
 }

--- a/app/generated/api/zod/schema.ts
+++ b/app/generated/api/zod/schema.ts
@@ -241,6 +241,7 @@ export const getNotesApiV1DataNotesGetResponseDataItemSomewhatHelpfulCountMin = 
 export const getNotesApiV1DataNotesGetResponseDataItemCurrentStatusHistoryItemDateMin = 1152921600000;
 export const getNotesApiV1DataNotesGetResponseMetaNextMaxOne = 2083;
 export const getNotesApiV1DataNotesGetResponseMetaPrevMaxOne = 2083;
+export const getNotesApiV1DataNotesGetResponseMetaTotalDefault = 0;
 
 export const getNotesApiV1DataNotesGetResponse = zod.object({
   data: zod
@@ -388,6 +389,7 @@ export const getNotesApiV1DataNotesGetResponse = zod.object({
       .or(zod.null())
       .optional()
       .describe("前のページのリクエスト用 URL"),
+    total: zod.number().optional().describe("検索結果の総件数"),
   }),
 });
 
@@ -503,6 +505,7 @@ export const getPostsApiV1DataPostsGetResponseDataItemLinksItemUrlMax = 2083;
 export const getPostsApiV1DataPostsGetResponseDataItemLinkMax = 2083;
 export const getPostsApiV1DataPostsGetResponseMetaNextMaxOne = 2083;
 export const getPostsApiV1DataPostsGetResponseMetaPrevMaxOne = 2083;
+export const getPostsApiV1DataPostsGetResponseMetaTotalDefault = 0;
 
 export const getPostsApiV1DataPostsGetResponse = zod.object({
   data: zod
@@ -641,6 +644,7 @@ export const getPostsApiV1DataPostsGetResponse = zod.object({
       .or(zod.null())
       .optional()
       .describe("前のページのリクエスト用 URL"),
+    total: zod.number().optional().describe("検索結果の総件数"),
   }),
 });
 
@@ -828,6 +832,7 @@ export const searchApiV1DataSearchGetResponseDataItemPostLinksItemUrlMax = 2083;
 export const searchApiV1DataSearchGetResponseDataItemPostLinkMax = 2083;
 export const searchApiV1DataSearchGetResponseMetaNextMaxOne = 2083;
 export const searchApiV1DataSearchGetResponseMetaPrevMaxOne = 2083;
+export const searchApiV1DataSearchGetResponseMetaTotalDefault = 0;
 
 export const searchApiV1DataSearchGetResponse = zod.object({
   data: zod
@@ -1068,6 +1073,7 @@ export const searchApiV1DataSearchGetResponse = zod.object({
       .or(zod.null())
       .optional()
       .describe("前のページのリクエスト用 URL"),
+    total: zod.number().optional().describe("検索結果の総件数"),
   }),
 });
 


### PR DESCRIPTION
## 概要
 PaginationMeta に total フィールドを追加し、SearchPagination で
 「X ～ Y 件目を表示中（全 N 件）」の形式で総件数を表示するようにした。
 生成コード（zod, msw）も API スキーマ変更に合わせて更新。

<!-- issue に関連する場合は、以下のようにリンクしてください -->
Closes #295 

## 変更内容
<!-- 具体的な変更内容を記載してください。複数の変更がある場合は、セクションに分けて記述してください -->

### 1. （変更内容のタイトル）
<!-- 変更の詳細を説明してください -->

## 補足
<!-- レビュアーに知っておいてほしい情報や、設計上の判断などを記載してください（任意） -->

## 効果
<!-- この変更によって得られる効果や改善点を記載してください（任意） -->

## テスト結果
<!-- 以下のチェックリストを確認してください -->
- [ ] `pnpm run lint` が成功すること
- [ ] `pnpm run typecheck` が成功すること
- [ ] `pnpm run test` が成功すること（該当する場合）
- [ ] `pnpm run build` が成功すること
