### PR TITLE
searchページにて、言語の順番を日本語と英語を先頭にする #297

### DIFF
--- a/app/feature/search/language.ts
+++ b/app/feature/search/language.ts
@@ -17,19 +17,19 @@ export const isLanguageIdentifierLiteral = (
 
 export const LANGUAGE_ID_TO_LABEL = {
   // 言語
+  ja: "日本語",
+  en: "英語",
   ar: "アラビア語",
   ca: "カタロニア語",
   da: "デンマーク語",
   de: "ドイツ語",
   el: "ギリシャ語",
-  en: "英語",
   es: "スペイン語",
   fa: "ペルシア語",
   fi: "フィンランド語",
   fr: "フランス語",
   he: "ヘブライ語",
   it: "イタリア語",
-  ja: "日本語",
   nl: "オランダ語",
   pl: "ポーランド語",
   pt: "ポルトガル語",


### PR DESCRIPTION
## 概要
検索ページの言語プルダウンで、日本語と英語を選択しやすくするため、表示順を調整しました。

Closes #297

## 変更内容
### 1. 言語プルダウンの表示順を調整
- `app/feature/search/language.ts` の `LANGUAGE_ID_TO_LABEL` の定義順を変更
- `ja` を先頭、`en` を2番目に移動
- それ以外の言語ID・ラベルは変更なし

## 補足
`LanguageSelect` は `Object.entries(languages)` の順序で選択肢を生成しているため、定義順の変更のみで簡易検索フォームと詳細検索フォームの両方に反映されます。

## 効果
日本語・英語が先頭表示になり、対象言語を選択するまでの操作コストが下がります。

## テスト結果
- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [x] `pnpm run test` が成功すること（該当する場合）
- [x] `pnpm run build` が成功すること
