### PR TITLE
fix: search empty state and hover UI consistency (#294, #302)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -143,3 +143,24 @@ body {
   background-color: var(--color-gray-2);
   color: white;
 }
+
+/* DatePickerInput hover color unification for ISSUE-302 */
+[data-dates-dropdown] .mantine-DatePickerInput-calendarHeaderControl:hover,
+[data-dates-dropdown] .mantine-DatePickerInput-calendarHeaderLevel:hover,
+[data-dates-dropdown] .mantine-DatePickerInput-monthsListControl:hover:not([data-selected]),
+[data-dates-dropdown] .mantine-DatePickerInput-yearsListControl:hover:not([data-selected]),
+[data-dates-dropdown] .mantine-DatePickerInput-day:hover:not([data-static]):not([data-disabled]):not(:disabled):not([data-selected]):not([data-in-range]),
+[data-dates-dropdown] .mantine-DatePickerInput-day[data-in-range]:hover:not([data-disabled]):not([data-static]) {
+  background-color: var(--color-gray-2);
+  color: white;
+}
+
+[data-dates-dropdown] .mantine-DatePickerInput-calendarHeaderControl:active,
+[data-dates-dropdown] .mantine-DatePickerInput-calendarHeaderLevel:active,
+[data-dates-dropdown] .mantine-DatePickerInput-monthsListControl:active:not([data-selected]),
+[data-dates-dropdown] .mantine-DatePickerInput-yearsListControl:active:not([data-selected]),
+[data-dates-dropdown] .mantine-DatePickerInput-day:active:not([data-static]):not([data-disabled]):not(:disabled):not([data-selected]):not([data-in-range]),
+[data-dates-dropdown] .mantine-DatePickerInput-day[data-in-range]:active:not([data-disabled]):not([data-static]) {
+  background-color: var(--color-gray-2);
+  color: white;
+}

--- a/app/components/account-ranking/AccountRankingSection.browser.test.tsx
+++ b/app/components/account-ranking/AccountRankingSection.browser.test.tsx
@@ -2,11 +2,13 @@ import { MantineProvider } from "@mantine/core";
 import { DatesProvider } from "@mantine/dates";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it } from "vitest";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { render } from "vitest-browser-react";
 
 import type { GraphFetchResult } from "~/components/graph";
 import { mantineTheme } from "~/config/mantine";
 import type { TopNoteAccountDataItem } from "~/generated/api/schemas/topNoteAccountDataItem";
+
 import { AccountRankingSection } from "./AccountRankingSection";
 
 const mockResult: GraphFetchResult<TopNoteAccountDataItem[]> = {

--- a/app/components/account-ranking/AccountRankingSection.browser.test.tsx
+++ b/app/components/account-ranking/AccountRankingSection.browser.test.tsx
@@ -1,7 +1,11 @@
+import { MantineProvider } from "@mantine/core";
+import { DatesProvider } from "@mantine/dates";
+import { createMemoryRouter, RouterProvider } from "react-router";
 import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
 
-import { render } from "../../../test/test-react";
 import type { GraphFetchResult } from "~/components/graph";
+import { mantineTheme } from "~/config/mantine";
 import type { TopNoteAccountDataItem } from "~/generated/api/schemas/topNoteAccountDataItem";
 import { AccountRankingSection } from "./AccountRankingSection";
 
@@ -15,14 +19,37 @@ const mockResult: GraphFetchResult<TopNoteAccountDataItem[]> = {
   ],
 };
 
+const renderWithDataRouter = () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: <AccountRankingSection initialResult={mockResult} />,
+      },
+    ],
+    {
+      initialEntries: ["/"],
+      initialIndex: 0,
+    },
+  );
+
+  return render(
+    <MantineProvider theme={mantineTheme}>
+      <DatesProvider settings={{ locale: "ja", consistentWeeks: true }}>
+        <RouterProvider router={router} />
+      </DatesProvider>
+    </MantineProvider>,
+  );
+};
+
 describe("AccountRankingSection", () => {
   it("should render the component with title", () => {
-    const screen = render(<AccountRankingSection initialResult={mockResult} />);
+    const screen = renderWithDataRouter();
     expect(screen.getByText("アカウントランキング")).toBeTruthy();
   });
 
   it("should display table headers correctly", () => {
-    const screen = render(<AccountRankingSection initialResult={mockResult} />);
+    const screen = renderWithDataRouter();
     expect(screen.getByText("順位")).toBeTruthy();
     expect(screen.getByText("ユーザー名")).toBeTruthy();
     expect(screen.getByText("付与数")).toBeTruthy();
@@ -30,14 +57,14 @@ describe("AccountRankingSection", () => {
   });
 
   it("should display ranking data in table rows", () => {
-    const screen = render(<AccountRankingSection initialResult={mockResult} />);
+    const screen = renderWithDataRouter();
     expect(screen.getByText("テストユーザー1")).toBeTruthy();
     expect(screen.getByText("544")).toBeTruthy();
     expect(screen.getByText("+12")).toBeTruthy();
   });
 
   it("should display rank numbers from API data", () => {
-    const screen = render(<AccountRankingSection initialResult={mockResult} />);
+    const screen = renderWithDataRouter();
     const table = screen.getByRole("table");
     const rows = table.element().querySelectorAll("tbody tr");
 
@@ -48,13 +75,13 @@ describe("AccountRankingSection", () => {
   });
 
   it("should handle period selection dropdown defaulting to 直近1週間", () => {
-    const { container } = render(<AccountRankingSection initialResult={mockResult} />);
+    const { container } = renderWithDataRouter();
     const select = container.querySelector("input");
     expect(select?.getAttribute("value")).toBe("直近1週間");
   });
 
   it("should apply correct color to change values", () => {
-    const screen = render(<AccountRankingSection initialResult={mockResult} />);
+    const screen = renderWithDataRouter();
 
     // Positive change should be green
     const positiveChange = screen.getByText("+12");
@@ -63,5 +90,14 @@ describe("AccountRankingSection", () => {
     // Negative change should be red
     const negativeChange = screen.getByText("-3");
     expect(negativeChange.element().classList.contains("text-red")).toBe(true);
+  });
+
+  it("should not set data-hover attribute on table rows", () => {
+    const screen = renderWithDataRouter();
+    const rows = screen.getByRole("table").element().querySelectorAll("tbody tr");
+
+    rows.forEach((row) => {
+      expect(row.getAttribute("data-hover")).toBeNull();
+    });
   });
 });

--- a/app/components/account-ranking/AccountRankingSection.tsx
+++ b/app/components/account-ranking/AccountRankingSection.tsx
@@ -135,7 +135,6 @@ export const AccountRankingSection = ({
         <GraphContainer>
           <div className="w-full overflow-x-auto">
             <Table
-              highlightOnHover
               horizontalSpacing={isMobile ? "xs" : "md"}
               striped="even"
               stripedColor="var(--color-gray-1)"

--- a/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
@@ -1,0 +1,31 @@
+import { userEvent } from "@vitest/browser/context";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import "~/app.css";
+
+import { render } from "../../../test/test-react";
+import { DateRangeSelector } from "./DateRangeSelector";
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DateRangeSelector", () => {
+  test("日付セルhover時に背景色がグレーになる", async () => {
+    vi.setSystemTime(new Date("2025-01-15T00:00:00Z"));
+
+    const screen = render(<DateRangeSelector onChange={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "期間を選択" });
+    await userEvent.click(button);
+
+    const hoveredDate = screen.getByRole("button", { name: "10 1月 2025" });
+    await userEvent.hover(hoveredDate);
+
+    expect(window.getComputedStyle(hoveredDate.element()).backgroundColor).toBe(
+      "rgb(85, 85, 85)",
+    );
+  });
+});

--- a/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
@@ -1,6 +1,7 @@
+import "~/app.css";
+
 import { userEvent } from "@vitest/browser/context";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import "~/app.css";
 
 import { render } from "../../../test/test-react";
 import { DateRangeSelector } from "./DateRangeSelector";

--- a/app/components/date-range-selector/DateRangeSelector.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.tsx
@@ -71,6 +71,7 @@ export const DateRangeSelector = ({
             backgroundColor: "var(--color-gray-1)",
           },
           calendarHeader: {
+            backgroundColor: "var(--color-gray-1)",
             color: "white",
           },
           calendarHeaderControl: {
@@ -85,10 +86,7 @@ export const DateRangeSelector = ({
               backgroundColor: "var(--color-gray-2)",
             },
           },
-          monthsList: {
-            backgroundColor: "var(--color-gray-1)",
-          },
-          yearsList: {
+          levelsGroup: {
             backgroundColor: "var(--color-gray-1)",
           },
           month: {
@@ -96,7 +94,7 @@ export const DateRangeSelector = ({
           },
           monthCell: {
             color: "white",
-            "&:hover": {
+            "&:hover:not([data-selected])": {
               backgroundColor: "var(--color-gray-2)",
             },
             "&[data-selected]": {
@@ -104,9 +102,31 @@ export const DateRangeSelector = ({
               color: "white",
             },
           },
-          yearCell: {
+          monthsList: {
+            backgroundColor: "var(--color-gray-1)",
+          },
+          monthsListCell: {
+            backgroundColor: "var(--color-gray-1)",
+          },
+          monthsListControl: {
             color: "white",
-            "&:hover": {
+            "&:hover:not([data-selected])": {
+              backgroundColor: "var(--color-gray-2)",
+            },
+            "&[data-selected]": {
+              backgroundColor: "var(--color-primary)",
+              color: "white",
+            },
+          },
+          yearsList: {
+            backgroundColor: "var(--color-gray-1)",
+          },
+          yearsListCell: {
+            backgroundColor: "var(--color-gray-1)",
+          },
+          yearsListControl: {
+            color: "white",
+            "&:hover:not([data-selected])": {
               backgroundColor: "var(--color-gray-2)",
             },
             "&[data-selected]": {
@@ -121,12 +141,14 @@ export const DateRangeSelector = ({
               color: "white",
             },
             "&[data-in-range]": {
-              backgroundColor: "rgba(var(--color-primary-rgb), 0.2)",
+              backgroundColor:
+                "color-mix(in srgb, var(--color-primary) 20%, transparent)",
               color: "white",
             },
-            "&:hover": {
-              backgroundColor: "var(--color-gray-2)",
-            },
+            "&:hover:not([data-selected]):not([data-in-range]):not([data-disabled]):not(:disabled):not([data-static])":
+              {
+                backgroundColor: "var(--color-gray-2)",
+              },
             "&[data-outside]": {
               color: "var(--color-gray-4)",
             },

--- a/app/components/date-range-selector/DateRangeSelector.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.tsx
@@ -1,6 +1,7 @@
+import "dayjs/locale/ja";
+
 import { DatePickerInput, DatesProvider } from "@mantine/dates";
 import { useMediaQuery } from "@mantine/hooks";
-import "dayjs/locale/ja";
 
 import { MOBILE_BREAKPOINT } from "~/constants/breakpoints";
 import Fa6RegularCalendar from "~icons/fa6-regular/calendar";
@@ -46,6 +47,15 @@ export const DateRangeSelector = ({
         minDate={minDate}
         onChange={onChange}
         placeholder={placeholder}
+        popoverProps={{
+          styles: {
+            dropdown: {
+              backgroundColor: "var(--color-gray-1)",
+              border: "1px solid var(--color-gray-2)",
+              borderRadius: "8px",
+            },
+          },
+        }}
         styles={{
           root: {
             maxWidth: "280px",
@@ -61,14 +71,6 @@ export const DateRangeSelector = ({
             minWidth: isMobile ? "220px" : "260px",
             paddingLeft: "36px",
             paddingRight: "12px",
-          },
-          dropdown: {
-            backgroundColor: "var(--color-gray-1)",
-            border: "1px solid var(--color-gray-2)",
-            borderRadius: "8px",
-          },
-          calendar: {
-            backgroundColor: "var(--color-gray-1)",
           },
           calendarHeader: {
             backgroundColor: "var(--color-gray-1)",

--- a/app/components/date-range-selector/DateRangeSelector.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.tsx
@@ -76,15 +76,9 @@ export const DateRangeSelector = ({
           },
           calendarHeaderControl: {
             color: "white",
-            "&:hover": {
-              backgroundColor: "var(--color-gray-2)",
-            },
           },
           calendarHeaderLevel: {
             color: "white",
-            "&:hover": {
-              backgroundColor: "var(--color-gray-2)",
-            },
           },
           levelsGroup: {
             backgroundColor: "var(--color-gray-1)",
@@ -94,9 +88,6 @@ export const DateRangeSelector = ({
           },
           monthCell: {
             color: "white",
-            "&:hover:not([data-selected])": {
-              backgroundColor: "var(--color-gray-2)",
-            },
             "&[data-selected]": {
               backgroundColor: "var(--color-primary)",
               color: "white",
@@ -110,9 +101,6 @@ export const DateRangeSelector = ({
           },
           monthsListControl: {
             color: "white",
-            "&:hover:not([data-selected])": {
-              backgroundColor: "var(--color-gray-2)",
-            },
             "&[data-selected]": {
               backgroundColor: "var(--color-primary)",
               color: "white",
@@ -126,9 +114,6 @@ export const DateRangeSelector = ({
           },
           yearsListControl: {
             color: "white",
-            "&:hover:not([data-selected])": {
-              backgroundColor: "var(--color-gray-2)",
-            },
             "&[data-selected]": {
               backgroundColor: "var(--color-primary)",
               color: "white",
@@ -145,10 +130,6 @@ export const DateRangeSelector = ({
                 "color-mix(in srgb, var(--color-primary) 20%, transparent)",
               color: "white",
             },
-            "&:hover:not([data-selected]):not([data-in-range]):not([data-disabled]):not(:disabled):not([data-static])":
-              {
-                backgroundColor: "var(--color-gray-2)",
-              },
             "&[data-outside]": {
               color: "var(--color-gray-4)",
             },

--- a/app/components/input/DateRangePicker.browser.test.tsx
+++ b/app/components/input/DateRangePicker.browser.test.tsx
@@ -1,6 +1,7 @@
 import { getFormProps, useForm } from "@conform-to/react";
 import { userEvent } from "@vitest/browser/context";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import "~/app.css";
 
 import { render } from "../../../test/test-react";
 import { DateRangePicker } from "./DateRangePicker";
@@ -18,6 +19,15 @@ type Form = {
 
 type PageProps = {
   defaultValue: Form;
+};
+
+const formatDateLabel = (isoString: string) => {
+  const date = new Date(isoString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const weekday = date.toLocaleDateString("ja-JP", { weekday: "short" });
+  return `${year}.${month}.${day} (${weekday})`;
 };
 
 beforeEach(() => {
@@ -71,9 +81,11 @@ describe("DateRangePicker", () => {
     const date2 = screen.getByRole("button", { name: "15 1月 2025" });
     await userEvent.click(date2);
 
+    const expectedStart = new Date(2025, 0, 10).toISOString();
+    const expectedEnd = new Date(2025, 0, 15).toISOString();
     const span = screen.getByLabelText("result");
     expect(span).toHaveTextContent(
-      "2025-01-10T00:00:00.000Z – 2025-01-15T00:00:00.000Z",
+      `${expectedStart} – ${expectedEnd}`,
     );
   });
 
@@ -88,6 +100,45 @@ describe("DateRangePicker", () => {
     );
 
     const button = screen.getByRole("button", { name: "Date Range" });
-    expect(button).toHaveTextContent("2025.01.09 (木) – 2025.01.14 (火)");
+    expect(button).toHaveTextContent(
+      `${formatDateLabel("2025-01-09T15:00:00.000Z")} – ${formatDateLabel("2025-01-14T15:00:00.000Z")}`,
+    );
+  });
+
+  test("日付セルhover時に背景色がグレーになる", async () => {
+    vi.setSystemTime(new Date("2025-01-15T00:00:00Z"));
+    const screen = render(<Page defaultValue={{ start: null, end: null }} />);
+
+    const button = screen.getByRole("button", { name: "Date Range" });
+    await userEvent.click(button);
+
+    const hoveredDate = screen.getByRole("button", { name: "10 1月 2025" });
+    await userEvent.hover(hoveredDate);
+
+    expect(window.getComputedStyle(hoveredDate.element()).backgroundColor).toBe(
+      "rgb(85, 85, 85)",
+    );
+  });
+
+  test("範囲内日付hover時にも背景色がグレーになる", async () => {
+    vi.setSystemTime(new Date("2025-01-15T00:00:00Z"));
+    const screen = render(<Page defaultValue={{ start: null, end: null }} />);
+
+    const button = screen.getByRole("button", { name: "Date Range" });
+    await userEvent.click(button);
+
+    const startDate = screen.getByRole("button", { name: "10 1月 2025" });
+    await userEvent.click(startDate);
+    const endDate = screen.getByRole("button", { name: "15 1月 2025" });
+    await userEvent.click(endDate);
+
+    await userEvent.click(button);
+    const inRangeDate = screen.getByRole("button", { name: "12 1月 2025" });
+    await userEvent.hover(inRangeDate);
+
+    expect(inRangeDate.element().getAttribute("data-in-range")).toBeTruthy();
+    expect(window.getComputedStyle(inRangeDate.element()).backgroundColor).toBe(
+      "rgb(85, 85, 85)",
+    );
   });
 });

--- a/app/components/input/DateRangePicker.browser.test.tsx
+++ b/app/components/input/DateRangePicker.browser.test.tsx
@@ -1,7 +1,8 @@
+import "~/app.css";
+
 import { getFormProps, useForm } from "@conform-to/react";
 import { userEvent } from "@vitest/browser/context";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import "~/app.css";
 
 import { render } from "../../../test/test-react";
 import { DateRangePicker } from "./DateRangePicker";

--- a/app/components/input/DateRangePicker.tsx
+++ b/app/components/input/DateRangePicker.tsx
@@ -90,15 +90,9 @@ export const DateRangePicker = ({
         },
         calendarHeaderControl: {
           color: "white",
-          "&:hover": {
-            backgroundColor: "var(--color-gray-2)",
-          },
         },
         calendarHeaderLevel: {
           color: "white",
-          "&:hover": {
-            backgroundColor: "var(--color-gray-2)",
-          },
         },
         levelsGroup: {
           backgroundColor: "var(--color-gray-1)",
@@ -108,9 +102,6 @@ export const DateRangePicker = ({
         },
         monthCell: {
           color: "white",
-          "&:hover:not([data-selected])": {
-            backgroundColor: "var(--color-gray-2)",
-          },
           "&[data-selected]": {
             backgroundColor: "var(--color-primary)",
             color: "white",
@@ -124,9 +115,6 @@ export const DateRangePicker = ({
         },
         monthsListControl: {
           color: "white",
-          "&:hover:not([data-selected])": {
-            backgroundColor: "var(--color-gray-2)",
-          },
           "&[data-selected]": {
             backgroundColor: "var(--color-primary)",
             color: "white",
@@ -140,9 +128,6 @@ export const DateRangePicker = ({
         },
         yearsListControl: {
           color: "white",
-          "&:hover:not([data-selected])": {
-            backgroundColor: "var(--color-gray-2)",
-          },
           "&[data-selected]": {
             backgroundColor: "var(--color-primary)",
             color: "white",
@@ -159,10 +144,6 @@ export const DateRangePicker = ({
               "color-mix(in srgb, var(--color-primary) 20%, transparent)",
             color: "white",
           },
-          "&:hover:not([data-selected]):not([data-in-range]):not([data-disabled]):not(:disabled):not([data-static])":
-            {
-              backgroundColor: "var(--color-gray-2)",
-            },
           "&[data-outside]": {
             color: "var(--color-gray-4)",
           },

--- a/app/components/input/DateRangePicker.tsx
+++ b/app/components/input/DateRangePicker.tsx
@@ -84,9 +84,6 @@ export const DateRangePicker = ({
         label: {
           marginBottom: "8px",
         },
-        levelsGroup: {
-          backgroundColor: "var(--color-gray-1)",
-        },
         calendarHeader: {
           backgroundColor: "var(--color-gray-1)",
           color: "white",
@@ -103,16 +100,7 @@ export const DateRangePicker = ({
             backgroundColor: "var(--color-gray-2)",
           },
         },
-        monthsList: {
-          backgroundColor: "var(--color-gray-1)",
-        },
-        monthsListCell: {
-          backgroundColor: "var(--color-gray-1)",
-        },
-        yearsList: {
-          backgroundColor: "var(--color-gray-1)",
-        },
-        yearsListCell: {
+        levelsGroup: {
           backgroundColor: "var(--color-gray-1)",
         },
         month: {
@@ -120,7 +108,7 @@ export const DateRangePicker = ({
         },
         monthCell: {
           color: "white",
-          "&:hover": {
+          "&:hover:not([data-selected])": {
             backgroundColor: "var(--color-gray-2)",
           },
           "&[data-selected]": {
@@ -128,19 +116,31 @@ export const DateRangePicker = ({
             color: "white",
           },
         },
-        yearsListControl: {
-          color: "white",
-          "&:hover": {
-            backgroundColor: "var(--color-gray-2)",
-          },
-          "&[data-selected]": {
-            backgroundColor: "var(--color-primary)",
-            color: "white",
-          },
+        monthsList: {
+          backgroundColor: "var(--color-gray-1)",
+        },
+        monthsListCell: {
+          backgroundColor: "var(--color-gray-1)",
         },
         monthsListControl: {
           color: "white",
-          "&:hover": {
+          "&:hover:not([data-selected])": {
+            backgroundColor: "var(--color-gray-2)",
+          },
+          "&[data-selected]": {
+            backgroundColor: "var(--color-primary)",
+            color: "white",
+          },
+        },
+        yearsList: {
+          backgroundColor: "var(--color-gray-1)",
+        },
+        yearsListCell: {
+          backgroundColor: "var(--color-gray-1)",
+        },
+        yearsListControl: {
+          color: "white",
+          "&:hover:not([data-selected])": {
             backgroundColor: "var(--color-gray-2)",
           },
           "&[data-selected]": {
@@ -155,12 +155,14 @@ export const DateRangePicker = ({
             color: "white",
           },
           "&[data-in-range]": {
-            backgroundColor: "rgba(var(--color-primary-rgb), 0.2)",
+            backgroundColor:
+              "color-mix(in srgb, var(--color-primary) 20%, transparent)",
             color: "white",
           },
-          "&:hover": {
-            backgroundColor: "var(--color-gray-2)",
-          },
+          "&:hover:not([data-selected]):not([data-in-range]):not([data-disabled]):not(:disabled):not([data-static])":
+            {
+              backgroundColor: "var(--color-gray-2)",
+            },
           "&[data-outside]": {
             color: "var(--color-gray-4)",
           },

--- a/app/components/input/DateRangePicker.tsx
+++ b/app/components/input/DateRangePicker.tsx
@@ -65,15 +65,15 @@ export const DateRangePicker = ({
       classNames={{ input: "!bg-gray-1 !border-gray-5" }}
       clearable
       disabled={disabled}
-      maxDate={new Date()}
-      getDayProps={getDayProps}
       error={
         containsNonNullValues(fromField.errors, toField.errors) && (
           <FormError errors={[fromField.errors, toField.errors]} />
         )
       }
       errorProps={{ component: "div" }}
+      getDayProps={getDayProps}
       label={label}
+      maxDate={new Date()}
       onBlur={onBlur}
       onChange={onChange}
       onFocus={onFocus}

--- a/app/routes/__tests__/_layout.search.browser.test.tsx
+++ b/app/routes/__tests__/_layout.search.browser.test.tsx
@@ -178,8 +178,11 @@ describe("Search Page", () => {
     expect(emptyStateContent).toBeTruthy();
     const emptyStateCard = emptyStateContent?.closest("[data-with-border]");
     expect(emptyStateCard).toBeTruthy();
+    if (!emptyStateCard) {
+      throw new Error("search-empty-state card not found");
+    }
     expect(
-      window.getComputedStyle(emptyStateCard as Element).backgroundColor,
+      window.getComputedStyle(emptyStateCard).backgroundColor,
     ).toBe("rgb(21, 32, 43)");
   });
 

--- a/app/routes/__tests__/_layout.search.browser.test.tsx
+++ b/app/routes/__tests__/_layout.search.browser.test.tsx
@@ -5,6 +5,7 @@
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 import "dayjs/locale/ja";
+import "~/app.css";
 
 import { MantineProvider } from "@mantine/core";
 import { DatesProvider } from "@mantine/dates";
@@ -139,7 +140,7 @@ describe("Search Page", () => {
     ).toBeTruthy();
   });
 
-  it("renders empty message when no search results", () => {
+  it("renders empty message when no search results", async () => {
     const mockLoaderData = {
       data: {
         topics: mockTopics,
@@ -160,9 +161,26 @@ describe("Search Page", () => {
 
     const screen = renderWithRouter(mockLoaderData);
 
+    await vi.waitFor(() => {
+      expect(screen.getByText("検索結果がありません").query()).toBeTruthy();
+    });
     expect(
-      screen.getByText("コミュニティノートが見つかりませんでした"),
+      screen
+        .getByText(
+          "該当するコミュニティノートが見つかりませんでした。検索条件を変更して再検索してください。",
+        )
+        .query(),
     ).toBeTruthy();
+
+    const emptyStateContent = screen
+      .getByTestId("search-empty-state-card")
+      .query();
+    expect(emptyStateContent).toBeTruthy();
+    const emptyStateCard = emptyStateContent?.closest("[data-with-border]");
+    expect(emptyStateCard).toBeTruthy();
+    expect(
+      window.getComputedStyle(emptyStateCard as Element).backgroundColor,
+    ).toBe("rgb(21, 32, 43)");
   });
 
   it("renders Notes when search results exist", () => {

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -152,17 +152,24 @@ export default function Search({
               </>
             ) : (
               <Card
+                bg="var(--color-twitter-dark-1)"
                 className="grid size-full place-content-center"
                 padding="lg"
                 radius="md"
                 w="100%"
                 withBorder
               >
-                <div className="flex flex-col items-center justify-center gap-4 text-white">
+                <div
+                  className="flex flex-col items-center justify-center gap-4 text-white"
+                  data-testid="search-empty-state-card"
+                >
                   <Fa6SolidMagnifyingGlass className="text-4xl text-current" />
-                  <span className="text-center text-lg font-semibold text-balance text-white">
-                    コミュニティノートが見つかりませんでした
-                  </span>
+                  <p className="text-center text-lg font-semibold text-balance text-white">
+                    検索結果がありません
+                  </p>
+                  <p className="text-center text-sm text-balance text-white">
+                    該当するコミュニティノートが見つかりませんでした。検索条件を変更して再検索してください。
+                  </p>
                 </div>
               </Card>
             )}


### PR DESCRIPTION
## 概要
searchページで検索結果が0件の場合に白く表示される問題（#294）と、Dashboard/Searchのhoverデザイン不統一（#302）を修正しました。

Closes #294  
Closes #302

## 変更内容
### 1. searchページの0件表示を改善（#294）
<img width="1179" height="623" alt="image" src="https://github.com/user-attachments/assets/12285872-87b4-41c1-a7d9-47cf600801d9" />

- `app/routes/_layout.search.tsx` の空結果表示を見直し、背景色を `var(--color-twitter-dark-1)` に変更
- 空結果時の文言を以下に更新
  - 見出し: `検索結果がありません`
  - 説明: `該当するコミュニティノートが見つかりませんでした。検索条件を変更して再検索してください。`
- テストしやすいように `data-testid="search-empty-state-card"` を追加

### 2. DatePickerのhover色を共通化（#302）
<img width="296" height="317" alt="image" src="https://github.com/user-attachments/assets/3e32ddfc-01c6-4520-ad43-22ccfeacd88e" />

- `app/app.css` に `[data-dates-dropdown]` 配下のhover/activeスタイルを追加し、日付セル・ヘッダー・月/年選択のhover色を統一
- `app/components/date-range-selector/DateRangeSelector.tsx` と `app/components/input/DateRangePicker.tsx` の個別hover指定を整理
- 範囲選択中の日付背景を `color-mix(...)` に変更し、テーマ変数ベースで一貫した見た目に調整

### 3. アカウントランキング行のhover表示を無効化（#302）
- `app/components/account-ranking/AccountRankingSection.tsx` の `Table` から `highlightOnHover` を削除

### 4. テスト追加・更新
- `app/components/date-range-selector/DateRangeSelector.browser.test.tsx` を追加
  - 日付セルhover時の背景色がグレーになることを検証
- `app/components/input/DateRangePicker.browser.test.tsx` を更新
  - hover色の検証を追加
  - 日付表示/値検証を環境依存しにくい形に調整
- `app/components/account-ranking/AccountRankingSection.browser.test.tsx` を更新
  - Data Router配下での描画に変更
  - 行に `data-hover` が付与されないことを検証
- `app/routes/__tests__/_layout.search.browser.test.tsx` を更新
  - 空結果時メッセージ・背景色の検証を追加

### 5. lint/typecheck整合対応
- `app/components/date-range-selector/DateRangeSelector.tsx`
  - `styles.dropdown` を `popoverProps.styles.dropdown` に移管し、`DatePickerInput` の型定義に適合
  - 型対象外の `styles.calendar` を削除
- `app/components/account-ranking/AccountRankingSection.browser.test.tsx`
  - `render` の import に対して行単位の eslint 例外コメントを追加
- `app/components/input/DateRangePicker.tsx`
  - `react/jsx-sort-props` に合わせて props の並び順を調整
- `app/components/date-range-selector/DateRangeSelector.browser.test.tsx` と `app/components/input/DateRangePicker.browser.test.tsx`
  - import 並び順を調整（`simple-import-sort/imports` 対応）
- `app/routes/__tests__/_layout.search.browser.test.tsx`
  - non-null assertion をやめ、null ガードで安全に型を絞り込み

## 補足
- DatePickerのhover色はグローバルCSSで管理し、同種UI間で見た目のズレが起きにくい構成にしています。
- 変更内容 5 は挙動変更ではなく、lint/typecheck の整合性を取るための実装です。

## 効果
- 検索結果0件時のUIが白くならず、状態と次アクションが明確になります。
- Dashboard/Searchの期間選択UIでhover挙動が統一され、視認性と一貫性が向上します。
- アカウントランキング表の不要なhover演出をなくし、意図しない遷移期待を抑制できます。

## テスト結果
- [x] `pnpm run lint` が成功すること
- [x] `pnpm run typecheck` が成功すること
- [x] `pnpm run test` が成功すること（該当する場合）
- [x] `pnpm run build` が成功すること
