### PR TITLE
fix: daily-notes cache test using wrong query params

### DIFF
--- a/app/routes/__tests__/resources.graphs.daily-notes.test.ts
+++ b/app/routes/__tests__/resources.graphs.daily-notes.test.ts
@@ -156,9 +156,9 @@ describe("resources.graphs.daily-notes loader", () => {
 
   it("uses separate cache for different parameters", async () => {
     const url1 =
-      "http://localhost/resources/graphs/daily-notes?period=1month&status=all";
+      "http://localhost/resources/graphs/daily-notes?start_date=1700000000000&end_date=1702592000000&status=all";
     const url2 =
-      "http://localhost/resources/graphs/daily-notes?period=3months&status=all";
+      "http://localhost/resources/graphs/daily-notes?start_date=1700000000000&end_date=1705184000000&status=all";
 
     await loader(createArgs(url1));
     expect(callCount).toBe(1);


### PR DESCRIPTION
## Summary
- キャッシュテストが `period` パラメータで異なるキャッシュキーを期待していたが、loaderは `start_date`/`end_date` のみ使用し `period` は無視する
- テストURLを `start_date`/`end_date` パラメータに変更して正しくキャッシュミスを検証するように修正

## Test plan
- [x] `npx vitest run --project node app/routes/__tests__/resources.graphs.daily-notes.test.ts` が全テスト通過