### PR TITLE
ci: run CI on dev branch pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -80,8 +82,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps
 
-      - name: Save Playwright Browser Cache if main branch
-        if: github.ref_name == 'main'
+      - name: Save Playwright Browser Cache if main or dev branch
+        if: github.ref_name == 'main' || github.ref_name == 'dev'
         id: save-pnpm-cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:


### PR DESCRIPTION
## Summary
- CIトリガーにdevブランチを追加（push + pull_request）
- devブランチへのPRでもESLint/Prettier/TypeCheck/Vitest/ブラウザテストが実行されるようになる
- Playwrightブラウザキャッシュの保存もdevブランチで有効化

## 背景
これまでCIはmainブランチへのpush/PRでのみ実行されていたため、devブランチでの問題がdev→mainのPR作成時まで検出されなかった。

## Test plan
- [ ] このPRマージ後、devへの次回PRでCIが実行されることを確認