### PR TITLE
feat: 検索件数の非同期取得で画面遷移を高速化

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -3,6 +3,6 @@
  * orval.config.ts の baseUrl と一致させること。
  * 環境変数 VITE_API_BASE_URL で上書き可能。
  */
-export const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL ||
+export const API_BASE_URL: string =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ??
   "https://dev.api-birdxplorer.code4japan.org";

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * BirdXplorer API のベースURL。
+ * orval.config.ts の baseUrl と一致させること。
+ * 環境変数 VITE_API_BASE_URL で上書き可能。
+ */
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  "https://dev.api-birdxplorer.code4japan.org";

--- a/app/feature/search/components/SearchPagination.tsx
+++ b/app/feature/search/components/SearchPagination.tsx
@@ -21,6 +21,7 @@ type PaginationProps = {
    * 検索結果として表示している現在のページに表示しているデータの件数
    */
   visibleItemCount: number;
+  totalCount?: number | null; // null = ローディング中, undefined = 利用不可
 } & GroupProps;
 
 export const SearchPagination = ({
@@ -28,6 +29,7 @@ export const SearchPagination = ({
   meta,
   loading,
   visibleItemCount,
+  totalCount,
   ...groupProps
 }: PaginationProps) => {
   const isNetworkBusy = useNetworkBusy();
@@ -69,7 +71,9 @@ export const SearchPagination = ({
     <Group {...groupProps}>
       <Text c="white">
         {pageFirstItemIndex} ～ {totalDisplayedItems} 件目を表示中
-        {meta.total != null && `（全 ${meta.total} 件）`}
+        {totalCount === null
+          ? "（件数計算中...）"
+          : totalCount != null && `（全 ${totalCount.toLocaleString()} 件）`}
       </Text>
       {prevTo ? (
         <ActionIcon

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable react-refresh/only-export-components */
 import { parseWithZod } from "@conform-to/zod";
 import { Card, Container, Divider, Group, Stack } from "@mantine/core";
+import { useEffect, useState } from "react";
 import { data, redirect } from "react-router";
 import { getQuery, withQuery } from "ufo";
 
 import { SearchIcon } from "~/components/icons";
 import { Notes } from "~/components/note/Notes";
+import { API_BASE_URL } from "~/constants";
 import { WEB_PATHS } from "~/constants/paths";
 import { SearchForm } from "~/feature/search/components/SearchForm";
 import { SearchPagination } from "~/feature/search/components/SearchPagination";
@@ -99,6 +101,41 @@ export default function Search({
   const paginationMeta =
     "meta" in searchResults ? searchResults.meta : { next: null, prev: null };
 
+  // 非同期件数取得
+  const [totalCount, setTotalCount] = useState<number | null | undefined>(null);
+  useEffect(() => {
+    setTotalCount(null);
+    if (!searchQuery) return;
+
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(searchQuery)) {
+      if (key === "offset" || key === "limit") continue;
+      if (value == null) continue;
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          params.append(key, String(v));
+        }
+      } else {
+        params.set(key, String(value));
+      }
+    }
+
+    const countUrl = `${API_BASE_URL}/api/v1/data/search/count?${params.toString()}`;
+    let cancelled = false;
+    fetch(countUrl)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) setTotalCount(data.total);
+      })
+      .catch(() => {
+        if (!cancelled) setTotalCount(undefined);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchQuery]);
+
   return (
     <main>
       <Container className="!px-0" size="xl">
@@ -124,6 +161,7 @@ export default function Search({
                       currentQuery={searchQuery}
                       loading={isNetworkBusy}
                       meta={paginationMeta}
+                      totalCount={totalCount}
                       visibleItemCount={notes.length}
                     />
                   )}
@@ -143,6 +181,7 @@ export default function Search({
                       currentQuery={searchQuery}
                       loading={isNetworkBusy}
                       meta={paginationMeta}
+                      totalCount={totalCount}
                       visibleItemCount={notes.length}
                     />
                   )}

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -122,8 +122,8 @@ export default function Search({
 
     const countUrl = `${API_BASE_URL}/api/v1/data/search/count?${params.toString()}`;
     let cancelled = false;
-    fetch(countUrl)
-      .then((res) => res.json())
+    void fetch(countUrl)
+      .then(async (res) => res.json() as Promise<{ total: number }>)
       .then((data) => {
         if (!cancelled) setTotalCount(data.total);
       })

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -77,7 +77,7 @@ export const loader = async (args: Route.LoaderArgs) => {
   const [topics, response] = await Promise.all([
     // TODO: Topics を毎回 fetch するのは無駄なので、ハードナビゲーション時に fetch してブラウザ側で状態管理するように変更する
     getTopicsApiV1DataTopicsGet(),
-    searchApiV1DataSearchGet(searchQuery.data),
+    searchApiV1DataSearchGet({ ...searchQuery.data, include_total: false } as never),
   ]);
 
   return {

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -77,7 +77,10 @@ export const loader = async (args: Route.LoaderArgs) => {
   const [topics, response] = await Promise.all([
     // TODO: Topics を毎回 fetch するのは無駄なので、ハードナビゲーション時に fetch してブラウザ側で状態管理するように変更する
     getTopicsApiV1DataTopicsGet(),
-    searchApiV1DataSearchGet({ ...searchQuery.data, include_total: false } as never),
+    searchApiV1DataSearchGet({
+      ...searchQuery.data,
+      include_total: false,
+    } as never),
   ]);
 
   return {


### PR DESCRIPTION
## Summary

- 検索ページの件数表示を非同期化し、画面遷移を高速化
- API の `include_total=false` パラメータを送信して COUNT クエリをスキップ
- 件数は `/search/count` エンドポイントからクライアントサイドで非同期取得

## 変更内容

- **`app/constants.ts`** (新規): API ベース URL を共通定数化（`VITE_API_BASE_URL` 環境変数で上書き可能）
- **`app/feature/search/components/SearchPagination.tsx`**: `totalCount` prop 追加。ローディング中は「件数計算中...」、取得後は「全 N 件」を表示
- **`app/routes/_layout.search.tsx`**: `useEffect` で `/search/count` を非同期フェッチ。検索 API に `include_total=false` を送信

## 依存関係

- **API 側 PR**: codeforjapan/BirdXplorer#234 のマージ・デプロイが先に必要
  - `/search/count` エンドポイントが存在しないと件数表示が「計算中...」のままになる
  - `include_total=false` パラメータがなくても後方互換（API がパラメータを無視して従来通り動作）

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] ローカル dev サーバーで検索ページ表示・動作確認
- [ ] API デプロイ後、件数が非同期で表示されることを確認