### PR TITLE
fix: ダッシュボード表示速度改善 + 検索→ダッシュボード遷移修正

### DIFF
--- a/app/components/account-ranking/AccountRankingSection.tsx
+++ b/app/components/account-ranking/AccountRankingSection.tsx
@@ -131,6 +131,7 @@ export const AccountRankingSection = ({
     >
       <GraphState
         error={currentResult?.ok ? undefined : currentResult?.error}
+        loadingHeight={400}
         onRetry={handleRetry}
         status={graphStatus}
       >

--- a/app/components/graph/EChartsGraph.tsx
+++ b/app/components/graph/EChartsGraph.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@mantine/core";
+import { Loader, Stack, Text } from "@mantine/core";
 import type { EChartsOption } from "echarts";
 import { useEffect, useState } from "react";
 
@@ -50,7 +50,21 @@ export const EChartsGraph = ({
   }, []);
 
   const fallback = loadingFallback ?? (
-    <Skeleton height={minHeight} radius="md" />
+    <Stack
+      align="center"
+      justify="center"
+      style={{
+        height,
+        minHeight,
+        borderRadius: "8px",
+        backgroundColor: "var(--color-gray-1)",
+      }}
+    >
+      <Loader color="blue" size="md" />
+      <Text c="dimmed" size="sm">
+        グラフを読み込み中...
+      </Text>
+    </Stack>
   );
 
   if (!ReactECharts) {

--- a/app/components/graph/EChartsGraph.tsx
+++ b/app/components/graph/EChartsGraph.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@mantine/core";
+import { Skeleton } from "@mantine/core";
 import type { EChartsOption } from "echarts";
 import { useEffect, useState } from "react";
 
@@ -50,12 +50,7 @@ export const EChartsGraph = ({
   }, []);
 
   const fallback = loadingFallback ?? (
-    <div
-      className="flex items-center justify-center"
-      style={{ height, minHeight }}
-    >
-      <Text c="dimmed">読み込み中...</Text>
-    </div>
+    <Skeleton height={minHeight} radius="md" />
   );
 
   if (!ReactECharts) {

--- a/app/components/graph/GraphLoading.tsx
+++ b/app/components/graph/GraphLoading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@mantine/core";
+import { Loader, Stack, Text } from "@mantine/core";
 
 export type GraphLoadingProps = {
   /** ローディング表示の高さ */
@@ -6,5 +6,20 @@ export type GraphLoadingProps = {
 };
 
 export const GraphLoading = ({ height = 320 }: GraphLoadingProps) => {
-  return <Skeleton height={height} radius="md" />;
+  return (
+    <Stack
+      align="center"
+      justify="center"
+      style={{
+        height,
+        borderRadius: "8px",
+        backgroundColor: "var(--color-gray-1)",
+      }}
+    >
+      <Loader color="blue" size="md" />
+      <Text c="dimmed" size="sm">
+        グラフを読み込み中...
+      </Text>
+    </Stack>
+  );
 };

--- a/app/components/graph/GraphState.browser.test.tsx
+++ b/app/components/graph/GraphState.browser.test.tsx
@@ -22,8 +22,8 @@ describe("GraphState", () => {
       </GraphState>,
     );
 
-    const skeleton = screen.container.querySelector(".mantine-Skeleton-root");
-    expect(skeleton).toBeTruthy();
+    const loader = screen.container.querySelector(".mantine-Loader-root");
+    expect(loader).toBeTruthy();
   });
 
   it("renders empty message", () => {

--- a/app/components/notes-annual-chart/NotesAnnualChartSection.tsx
+++ b/app/components/notes-annual-chart/NotesAnnualChartSection.tsx
@@ -249,6 +249,7 @@ export const NotesAnnualChartSection = ({
     >
       <GraphState
         error={currentResult?.ok ? undefined : currentResult?.error}
+        loadingHeight={400}
         onRetry={handleRetry}
         status={graphStatus}
       >

--- a/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
+++ b/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
@@ -146,6 +146,7 @@ export const NotesEvaluationChartSection = ({
     >
       <GraphState
         error={currentResult?.ok ? undefined : currentResult?.error}
+        loadingHeight={400}
         onRetry={handleRetry}
         status={graphStatus}
       >

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -37,10 +37,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <Meta />
         <Links />
-        <ColorSchemeScript />
+        <ColorSchemeScript defaultColorScheme="dark" />
       </head>
       <body className="overflow-x-hidden bg-black">
-        <MantineProvider theme={mantineTheme}>
+        <MantineProvider defaultColorScheme="dark" theme={mantineTheme}>
           <DatesProvider settings={{ locale: "ja", consistentWeeks: true }}>
             {children}
           </DatesProvider>
@@ -101,10 +101,10 @@ export function ErrorBoundary() {
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <Meta />
         <Links />
-        <ColorSchemeScript />
+        <ColorSchemeScript defaultColorScheme="dark" />
       </head>
       <body className="overflow-x-hidden bg-black">
-        <MantineProvider theme={mantineTheme}>
+        <MantineProvider defaultColorScheme="dark" theme={mantineTheme}>
           <div className="flex min-h-dvh items-center justify-center bg-black text-white">
             <div className="text-center">
               <h1 className="mb-4 text-2xl font-bold">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,11 +3,25 @@ import "@mantine/dates/styles.css";
 import "dayjs/locale/ja";
 import "./app.css";
 
-import { ColorSchemeScript, Container, MantineProvider } from "@mantine/core";
+import {
+  ColorSchemeScript,
+  Container,
+  MantineProvider,
+  Progress,
+} from "@mantine/core";
 import { DatesProvider } from "@mantine/dates";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useNavigation,
+  useRouteError,
+} from "react-router";
 
 import { LogoIcon } from "./components/logo";
 import { MobileMenuButton, SideMenu } from "./components/SideMenu";
@@ -39,8 +53,20 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  const navigation = useNavigation();
+  const isNavigating = navigation.state !== "idle";
+
   return (
     <div className="flex min-h-dvh flex-col bg-black">
+      {isNavigating && (
+        <Progress
+          animated
+          className="fixed top-0 right-0 left-0 z-[9999]"
+          color="blue"
+          size="xs"
+          value={100}
+        />
+      )}
       <header className="flex items-center justify-between bg-black px-5 py-4 md:hidden">
         <a href="/">
           <LogoIcon />
@@ -62,5 +88,43 @@ export default function App() {
         </Container>
       </footer>
     </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  return (
+    <html lang="ja">
+      <head>
+        <meta charSet="utf-8" />
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <Meta />
+        <Links />
+        <ColorSchemeScript />
+      </head>
+      <body>
+        <MantineProvider theme={mantineTheme}>
+          <div className="flex min-h-dvh items-center justify-center bg-black text-white">
+            <div className="text-center">
+              <h1 className="mb-4 text-2xl font-bold">
+                {isRouteErrorResponse(error)
+                  ? `${String(error.status)} Error`
+                  : "エラーが発生しました"}
+              </h1>
+              <p className="mb-8">
+                {isRouteErrorResponse(error)
+                  ? error.statusText
+                  : "予期しないエラーが発生しました。"}
+              </p>
+              <a className="text-blue-400 underline" href="/">
+                トップページに戻る
+              </a>
+            </div>
+          </div>
+        </MantineProvider>
+        <Scripts />
+      </body>
+    </html>
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -39,7 +39,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
         <ColorSchemeScript />
       </head>
-      <body>
+      <body className="overflow-x-hidden bg-black">
         <MantineProvider theme={mantineTheme}>
           <DatesProvider settings={{ locale: "ja", consistentWeeks: true }}>
             {children}
@@ -75,7 +75,7 @@ export default function App() {
       </header>
       <div className="flex flex-1 bg-black">
         <SideMenu className="hidden md:flex" />
-        <main className="flex-1 bg-black">
+        <main className="min-w-0 flex-1 overflow-hidden bg-black">
           <Outlet />
         </main>
       </div>
@@ -103,7 +103,7 @@ export function ErrorBoundary() {
         <Links />
         <ColorSchemeScript />
       </head>
-      <body>
+      <body className="overflow-x-hidden bg-black">
         <MantineProvider theme={mantineTheme}>
           <div className="flex min-h-dvh items-center justify-center bg-black text-white">
             <div className="text-center">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,113 +4,22 @@ import { AboutSection } from "~/components/about-section";
 import { AccountRankingSection } from "~/components/account-ranking";
 import { AutoResizeIframe } from "~/components/auto-resize-iframe/AutoResizeIframe";
 import { FeatureSection } from "~/components/feature-section";
-import type { GraphFetchResult } from "~/components/graph";
-import type {
-  MonthlyNoteData,
-  NoteEvaluationData,
-  StatusValue,
-} from "~/components/graph";
-import {
-  DEFAULT_GRAPH_LIMIT,
-  fetchNotesAnnualGraph,
-  fetchNotesEvaluationGraph,
-  safeGraphFetch,
-} from "~/components/graph/graphFetchers";
 import { FeatureIcon } from "~/components/icons";
 import { NotesAnnualChartSection } from "~/components/notes-annual-chart";
 import { NotesEvaluationChartSection } from "~/components/notes-evaluation-chart";
 import { PageTitle } from "~/components/PageTitle";
 import { ReportCardSection } from "~/components/report-card-section/ReportCardSection";
-import {
-  getDefault12MonthRange,
-  getDefault14DayRange,
-} from "~/utils/dateRange";
-import { buildGraphCacheKey, graphCache } from "~/utils/graphCache";
 
 import type { Route } from "./+types/_index";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// グラフデータはクライアントサイドで useFetcher 経由で取得する。
+// loader でブロッキング API 呼び出しを行うと画面遷移が止まるため削除。
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
 export const loader = async (_args: Route.LoaderArgs) => {
-  const status: StatusValue = "all";
-
-  // デフォルトの日付範囲を設定
-  const defaultNotesAnnualTimestamps = getDefault12MonthRange();
-  const defaultEvaluationTimestamps = getDefault14DayRange();
-
-  // キャッシュキー構築
-  const notesAnnualKey = buildGraphCacheKey("notes-annual", {
-    start_date: defaultNotesAnnualTimestamps.start_date,
-    end_date: defaultNotesAnnualTimestamps.end_date,
-    status,
-  });
-  const notesEvaluationKey = buildGraphCacheKey("notes-evaluation", {
-    start_date: defaultEvaluationTimestamps.start_date,
-    end_date: defaultEvaluationTimestamps.end_date,
-    status,
-    limit: DEFAULT_GRAPH_LIMIT,
-  });
-
-  // キャッシュ確認
-  const notesAnnualCached = graphCache.get(notesAnnualKey) as
-    | GraphFetchResult<MonthlyNoteData[]>
-    | undefined;
-  const notesEvaluationCached = graphCache.get(notesEvaluationKey) as
-    | GraphFetchResult<NoteEvaluationData[]>
-    | undefined;
-
-  const settled = await Promise.allSettled([
-    notesAnnualCached
-      ? Promise.resolve(notesAnnualCached)
-      : safeGraphFetch(async () => {
-          const result = await fetchNotesAnnualGraph({
-            start_date: defaultNotesAnnualTimestamps.start_date,
-            end_date: defaultNotesAnnualTimestamps.end_date,
-            status,
-          });
-          if (result.ok) graphCache.set(notesAnnualKey, result);
-          return result;
-        }),
-    notesEvaluationCached
-      ? Promise.resolve(notesEvaluationCached)
-      : safeGraphFetch(async () => {
-          const result = await fetchNotesEvaluationGraph({
-            start_date: defaultEvaluationTimestamps.start_date,
-            end_date: defaultEvaluationTimestamps.end_date,
-            status,
-            limit: DEFAULT_GRAPH_LIMIT,
-          });
-          if (result.ok) graphCache.set(notesEvaluationKey, result);
-          return result;
-        }),
-  ]);
-
-  const notesAnnual =
-    settled[0].status === "fulfilled"
-      ? settled[0].value
-      : ({
-          ok: false,
-          error: {
-            kind: "network",
-            message:
-              "通信エラーが発生しました。時間をおいて再試行してください。",
-          },
-        } as GraphFetchResult<MonthlyNoteData[]>);
-  const notesEvaluation =
-    settled[1].status === "fulfilled"
-      ? settled[1].value
-      : ({
-          ok: false,
-          error: {
-            kind: "network",
-            message:
-              "通信エラーが発生しました。時間をおいて再試行してください。",
-          },
-        } as GraphFetchResult<NoteEvaluationData[]>);
-
   return {
     graphs: {
-      notesAnnual,
-      notesEvaluation,
+      notesAnnual: undefined,
+      notesEvaluation: undefined,
     },
   };
 };

--- a/app/routes/_layout.search.tsx
+++ b/app/routes/_layout.search.tsx
@@ -74,8 +74,8 @@ export const loader = async (args: Route.LoaderArgs) => {
     );
   }
 
-  const [topics, response] = await Promise.all([
-    // TODO: Topics を毎回 fetch するのは無駄なので、ハードナビゲーション時に fetch してブラウザ側で状態管理するように変更する
+  // TODO: Topics を毎回 fetch するのは無駄なので、ハードナビゲーション時に fetch してブラウザ側で状態管理するように変更する
+  const settled = await Promise.allSettled([
     getTopicsApiV1DataTopicsGet(),
     searchApiV1DataSearchGet({
       ...searchQuery.data,
@@ -83,11 +83,18 @@ export const loader = async (args: Route.LoaderArgs) => {
     } as never),
   ]);
 
+  const topics =
+    settled[0].status === "fulfilled" ? settled[0].value.data.data : [];
+  const searchResults =
+    settled[1].status === "fulfilled"
+      ? settled[1].value.data
+      : { data: [], meta: { next: null, prev: null } };
+
   return {
     data: {
       searchQuery: searchQuery.data,
-      searchResults: response.data,
-      topics: topics.data.data,
+      searchResults,
+      topics,
     },
     error: null,
   };


### PR DESCRIPTION
## Summary

- ダッシュボードの loader からブロッキング API 呼び出しを削除し、ページ遷移を即座に
- グローバルナビゲーション Progress バー追加
- ルート ErrorBoundary 追加（未処理エラー時の復帰 UI）
- 検索 loader のエラーハンドリング修正（`Promise.all` → `Promise.allSettled`）
- グラフ読み込み中のローディング表示改善（スピナー + テキスト、ダーク背景）

## 変更内容

### ダッシュボード高速化
ダッシュボード loader でグラフ API を SSR ブロッキング取得していたのを削除。グラフコンポーネントは既に `useFetcher` でクライアントサイド取得する仕組みを持っているため、`initialResult=undefined` で即座に描画し、データは非同期で取得される。

### ナビゲーション修正
React Router はターゲット route の loader 完了まで画面遷移しないため、遅い loader があると遷移が「動かない」ように見えていた。loader のブロッキング除去と、Progress バーの追加で解決。

### エラーハンドリング
検索 loader が `Promise.all()` を使用しており、API 500 時に未処理 reject → React tree クラッシュ → 以降のナビゲーション不可能になっていた。`Promise.allSettled()` に変更し、空の結果で graceful に描画。

### ローディング表示
ECharts の動的インポート中と、グラフデータ取得中に白い領域が表示されていた。Mantine Skeleton は hydration mismatch でライトテーマの色になるため、CSS 変数 `--color-gray-1` (#171717) を直接使用したダーク背景 + Loader スピナーに変更。

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `app/routes/_index.tsx` | loader 簡素化（API fetch 削除） |
| `app/root.tsx` | Progress バー + ErrorBoundary 追加 |
| `app/routes/_layout.search.tsx` | `Promise.allSettled` + fallback |
| `app/components/graph/EChartsGraph.tsx` | ローディングフォールバック改善 |
| `app/components/graph/GraphLoading.tsx` | スピナー + テキスト表示 |
| `app/components/notes-annual-chart/NotesAnnualChartSection.tsx` | loadingHeight=400 |
| `app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx` | loadingHeight=400 |
| `app/components/account-ranking/AccountRankingSection.tsx` | loadingHeight=400 |

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm eslint` 通過
- [x] `pnpm prettier --check` 通過
- [x] ローカルで検索→ダッシュボード遷移が即座に動作確認
- [x] ダッシュボードでスピナー→グラフ表示の流れ確認
- [x] API エンドポイント計測: グラフ API は全て 0.1s 以下、問題は `/search` の 26.7s のみ