### PR TITLE
fix: ダークテーマ対応 — Progress バー削除 + セレクタ色修正

### DIFF
--- a/app/feature/search/components/input/LanguageSelect.tsx
+++ b/app/feature/search/components/input/LanguageSelect.tsx
@@ -53,6 +53,13 @@ export const LanguageSelect = ({
         label: {
           marginBottom: "8px",
         },
+        dropdown: {
+          backgroundColor: "var(--color-gray-1)",
+          borderColor: "var(--color-gray-5)",
+        },
+        option: {
+          color: "white",
+        },
       }}
       {...(getSelectProps(field) as Omit<
         ReturnType<typeof getSelectProps>,

--- a/app/feature/search/components/input/TopicSelect.tsx
+++ b/app/feature/search/components/input/TopicSelect.tsx
@@ -85,6 +85,13 @@ export const TopicSelect = ({
         label: {
           marginBottom: "8px",
         },
+        dropdown: {
+          backgroundColor: "var(--color-gray-1)",
+          borderColor: "var(--color-gray-5)",
+        },
+        option: {
+          color: "white",
+        },
       }}
       value={value}
       {...rest}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,12 +3,7 @@ import "@mantine/dates/styles.css";
 import "dayjs/locale/ja";
 import "./app.css";
 
-import {
-  ColorSchemeScript,
-  Container,
-  MantineProvider,
-  Progress,
-} from "@mantine/core";
+import { ColorSchemeScript, Container, MantineProvider } from "@mantine/core";
 import { DatesProvider } from "@mantine/dates";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
@@ -19,7 +14,6 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useNavigation,
   useRouteError,
 } from "react-router";
 
@@ -53,20 +47,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const navigation = useNavigation();
-  const isNavigating = navigation.state !== "idle";
-
   return (
     <div className="flex min-h-dvh flex-col bg-black">
-      {isNavigating && (
-        <Progress
-          animated
-          className="fixed top-0 right-0 left-0 z-[9999]"
-          color="blue"
-          size="xs"
-          value={100}
-        />
-      )}
       <header className="flex items-center justify-between bg-black px-5 py-4 md:hidden">
         <a href="/">
           <LogoIcon />


### PR DESCRIPTION
## Summary

- グローバルナビゲーション Progress バーを削除（不要なUI要素）
- トピック・言語セレクタのドロップダウン色をダークテーマ対応

## 変更内容

### Progress バー削除 (`app/root.tsx`)
`useNavigation` による画面上部の青い Progress バーを削除。`defaultColorScheme="dark"` 導入後に目立ちすぎるため。

### セレクタ色修正
`defaultColorScheme="dark"` 変更に伴い、`MultiSelect`/`Select` のドロップダウンオプションのテキストが見えなくなっていた。`dropdown` と `option` のスタイルを明示設定。

| ファイル | 変更 |
|---------|------|
| `app/root.tsx` | Progress, useNavigation 削除 |
| `app/feature/search/components/input/TopicSelect.tsx` | dropdown/option スタイル追加 |
| `app/feature/search/components/input/LanguageSelect.tsx` | dropdown/option スタイル追加 |

## Test plan

- [x] ESLint 通過
- [x] Prettier 通過
- [ ] トピックセレクタのドロップダウンで白テキストが表示されること
- [ ] 言語セレクタのドロップダウンで白テキストが表示されること