### PR TITLE
feat: DateRangeSelectorに最大日数バリデーション追加

### DIFF
--- a/app/components/daily-notes-creation-chart/DailyNotesCreationChart.tsx
+++ b/app/components/daily-notes-creation-chart/DailyNotesCreationChart.tsx
@@ -169,6 +169,7 @@ export const DailyNotesCreationChart = ({
   return (
     <GraphWrapper
       dateRange={dateRange}
+      maxRangeDays={30}
       onDateRangeChange={initialDateRange ? undefined : setDateRange}
       title="コミュニティノートの日別作成数"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}

--- a/app/components/daily-post-count-chart/DailyPostCountChart.tsx
+++ b/app/components/daily-post-count-chart/DailyPostCountChart.tsx
@@ -178,6 +178,7 @@ export const DailyPostCountChart = ({
   return (
     <GraphWrapper
       dateRange={dateRange}
+      maxRangeDays={30}
       onDateRangeChange={initialDateRange ? undefined : setDateRange}
       title="ノートがついたポストの日別投稿数"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}

--- a/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.browser.test.tsx
@@ -29,4 +29,55 @@ describe("DateRangeSelector", () => {
       "rgb(85, 85, 85)",
     );
   });
+
+  test("maxRangeDays指定時、開始日から制限日数を超える日付が選択不可になる", async () => {
+    vi.setSystemTime(new Date("2025-01-15T00:00:00Z"));
+
+    const onChange = vi.fn();
+    // 開始日が1/5に選択済み、終了日は未選択
+    const screen = render(
+      <DateRangeSelector
+        maxRangeDays={7}
+        onChange={onChange}
+        value={[new Date("2025-01-05T00:00:00Z"), null]}
+      />,
+    );
+
+    // カレンダーを開く（value設定時は日付テキストが表示される）
+    const button = screen.getByRole("button", { name: /2025\/01\/05/ });
+    await userEvent.click(button);
+
+    // カレンダーが表示されるまで待機
+    const withinRange = screen.getByRole("button", { name: "12 1月 2025" });
+    await expect.element(withinRange).toBeVisible();
+
+    // 1/12 (開始日+7日) は選択可能
+    expect(withinRange.element().hasAttribute("data-disabled")).toBe(false);
+
+    // 1/13 (開始日+8日) は選択不可
+    const outsideRange = screen.getByRole("button", { name: "13 1月 2025" });
+    expect(outsideRange.element().hasAttribute("data-disabled")).toBe(true);
+  });
+
+  test("maxRangeDays未指定時、日付制限がかからない", async () => {
+    vi.setSystemTime(new Date("2025-01-15T00:00:00Z"));
+
+    const onChange = vi.fn();
+    const screen = render(
+      <DateRangeSelector
+        onChange={onChange}
+        value={[new Date("2025-01-05T00:00:00Z"), null]}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /2025\/01\/05/ });
+    await userEvent.click(button);
+
+    // カレンダーが表示されるまで待機
+    const date = screen.getByRole("button", { name: "13 1月 2025" });
+    await expect.element(date).toBeVisible();
+
+    // 1/13 が選択可能なまま
+    expect(date.element().hasAttribute("data-disabled")).toBe(false);
+  });
 });

--- a/app/components/date-range-selector/DateRangeSelector.tsx
+++ b/app/components/date-range-selector/DateRangeSelector.tsx
@@ -2,6 +2,8 @@ import "dayjs/locale/ja";
 
 import { DatePickerInput, DatesProvider } from "@mantine/dates";
 import { useMediaQuery } from "@mantine/hooks";
+import dayjs from "dayjs";
+import { useMemo } from "react";
 
 import { MOBILE_BREAKPOINT } from "~/constants/breakpoints";
 import Fa6RegularCalendar from "~icons/fa6-regular/calendar";
@@ -19,6 +21,8 @@ export type DateRangeSelectorProps = {
   minDate?: Date;
   /** 選択可能な最大日付 */
   maxDate?: Date;
+  /** 選択可能な最大日数幅（開始日からの日数） */
+  maxRangeDays?: number;
 };
 
 /**
@@ -33,9 +37,18 @@ export const DateRangeSelector = ({
   placeholder = "期間を選択",
   minDate,
   maxDate,
+  maxRangeDays,
 }: DateRangeSelectorProps) => {
   // スマホ判定（640px以下）- SSR時はデスクトップ表示をデフォルトとする
   const isMobile = useMediaQuery(MOBILE_BREAKPOINT) ?? false;
+
+  // 開始日が選択済みかつ終了日が未選択のとき、maxRangeDays に基づいて最大日付を制限する
+  const effectiveMaxDate = useMemo(() => {
+    if (!maxRangeDays || !value?.[0] || value[1]) return maxDate;
+    const rangeLimit = dayjs(value[0]).add(maxRangeDays, "day").toDate();
+    if (!maxDate) return rangeLimit;
+    return rangeLimit < maxDate ? rangeLimit : maxDate;
+  }, [maxRangeDays, value, maxDate]);
 
   return (
     <DatesProvider settings={{ locale: "ja" }}>
@@ -43,7 +56,7 @@ export const DateRangeSelector = ({
         allowSingleDateInRange
         clearable
         leftSection={<Fa6RegularCalendar className="size-4 text-primary" />}
-        maxDate={maxDate}
+        maxDate={effectiveMaxDate}
         minDate={minDate}
         onChange={onChange}
         placeholder={placeholder}

--- a/app/components/graph/GraphWrapper.tsx
+++ b/app/components/graph/GraphWrapper.tsx
@@ -20,6 +20,8 @@ type GraphWrapperProps<T extends string = string> = {
   dateRange?: DateRange;
   /** DateRangeSelectorの変更コールバック */
   onDateRangeChange?: (value: DateRange) => void;
+  /** DateRangeSelectorの最大日数幅 */
+  maxRangeDays?: number;
   /** PeriodSelectorを使う場合の期間値（後方互換性のため） */
   onPeriodChange?: (value: T) => void;
   period?: T;
@@ -42,6 +44,7 @@ export const GraphWrapper = <T extends string = string>({
   helpText,
   dateRange,
   onDateRangeChange,
+  maxRangeDays,
   period,
   onPeriodChange,
   periodOptions,
@@ -105,7 +108,7 @@ export const GraphWrapper = <T extends string = string>({
 
         {/* DateRangeSelectorまたはPeriodSelectorを表示 */}
         {shouldShowDateRangeSelector ? (
-          <DateRangeSelector onChange={onDateRangeChange} value={dateRange} />
+          <DateRangeSelector maxRangeDays={maxRangeDays} onChange={onDateRangeChange} value={dateRange} />
         ) : shouldShowPeriodSelector ? (
           <PeriodSelector
             onChange={onPeriodChange}

--- a/app/components/graph/GraphWrapper.tsx
+++ b/app/components/graph/GraphWrapper.tsx
@@ -108,7 +108,11 @@ export const GraphWrapper = <T extends string = string>({
 
         {/* DateRangeSelectorまたはPeriodSelectorを表示 */}
         {shouldShowDateRangeSelector ? (
-          <DateRangeSelector maxRangeDays={maxRangeDays} onChange={onDateRangeChange} value={dateRange} />
+          <DateRangeSelector
+            maxRangeDays={maxRangeDays}
+            onChange={onDateRangeChange}
+            value={dateRange}
+          />
         ) : shouldShowPeriodSelector ? (
           <PeriodSelector
             onChange={onPeriodChange}

--- a/app/components/notes-annual-chart/NotesAnnualChartSection.tsx
+++ b/app/components/notes-annual-chart/NotesAnnualChartSection.tsx
@@ -243,6 +243,7 @@ export const NotesAnnualChartSection = ({
     <GraphWrapper
       dateRange={dateRange}
       helpText={helpText}
+      maxRangeDays={365}
       onDateRangeChange={setDateRange}
       title="1年間のコミュニティノート数と公開率"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}

--- a/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
+++ b/app/components/notes-evaluation-chart/NotesEvaluationChartSection.tsx
@@ -140,6 +140,7 @@ export const NotesEvaluationChartSection = ({
     <GraphWrapper
       className={className}
       dateRange={dateRange}
+      maxRangeDays={30}
       onDateRangeChange={setDateRange}
       title="コミュニティーノート評価分布図"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}

--- a/app/components/notes-evaluation-status-chart/NotesEvaluationStatusChart.tsx
+++ b/app/components/notes-evaluation-status-chart/NotesEvaluationStatusChart.tsx
@@ -158,6 +158,7 @@ export const NotesEvaluationStatusChart = ({
   return (
     <GraphWrapper
       dateRange={dateRange}
+      maxRangeDays={30}
       onDateRangeChange={initialDateRange ? undefined : setDateRange}
       title="コミュニティノートの評価状況"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}

--- a/app/components/post-influence-chart/PostInfluenceChart.tsx
+++ b/app/components/post-influence-chart/PostInfluenceChart.tsx
@@ -156,6 +156,7 @@ export const PostInfluenceChart = ({
   return (
     <GraphWrapper
       dateRange={dateRange}
+      maxRangeDays={30}
       onDateRangeChange={initialDateRange ? undefined : setDateRange}
       title="ノートがついたポストの影響力"
       updatedAt={currentResult?.ok ? currentResult.updatedAt : undefined}


### PR DESCRIPTION
## Summary
- `DateRangeSelector`に`maxRangeDays` propを追加。開始日選択後、カレンダー上で制限日数を超える日付を選択不可にする
- `GraphWrapper`経由で各チャートコンポーネントに`maxRangeDays`を透過的に渡す
- 評価分布図・評価状況・ポスト影響力の3チャートに`maxRangeDays={30}`を設定（API側の30日制限に合わせる）

## Related
- API側修正: https://github.com/codeforjapan/BirdXplorer/pull/235

## Test plan
- [x] ブラウザテスト追加（maxRangeDays有効時に制限日数超の日付が選択不可になることを検証）
- [x] ビルド成功
- [x] ローカルで30日範囲の日付選択が正しく動作することを確認