### PR TITLE
ci: lint/typecheck/build/test-node を並行ジョブに分割

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,41 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: Code Problem Check
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/workflows/composite/setup
+
+      - name: Run ESLint
+        run: pnpm run lint
+
+      - name: Run Prettier
+        run: pnpm run format:ci
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/workflows/composite/setup
+
+      - name: Run typecheck
+        run: pnpm run typecheck
+
+  build:
+    name: Build
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -37,14 +70,17 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Run ESLint
-        run: pnpm run lint
+  test-node:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Run Prettier
-        run: pnpm run format:ci
-
-      - name: Run typecheck
-        run: pnpm run typecheck
+      - name: Setup Node.js and pnpm
+        uses: ./.github/workflows/composite/setup
 
       - name: Run Vitest
         run: pnpm run test:node


### PR DESCRIPTION
## Summary

- 直列実行していた `ci` ジョブを `lint` / `typecheck` / `build` / `test-node` の4ジョブに分割し、並行実行するように変更
- `postinstall` で `react-router typegen` が走るため、`pnpm install` 後は全ジョブが独立して実行可能
- `browser-test` は既存通り独立ジョブ

## Before / After

**Before:** Build → ESLint → Prettier → Typecheck → Vitest (直列)

**After:**
```
lint (ESLint + Prettier) ─┐
typecheck                 ─┤ 並行
build                     ─┤
test-node (Vitest)        ─┘
browser-test              ─ (変更なし)
```

## Test plan

- [ ] CI が GitHub Actions 上で全ジョブ並行起動することを確認
- [ ] 各ジョブが独立して pass/fail することを確認

closes #338