### PR TITLE
ci: dev push 時に main への release PR を自動作成・更新

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,98 @@
+name: Release PR
+
+on:
+  push:
+    branches:
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    name: Create or Update Release PR
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Create or update Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          git fetch origin main dev
+
+          MERGE_BASE=$(git merge-base origin/main origin/dev)
+          AHEAD=$(git rev-list --count origin/main..origin/dev)
+
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "dev is up to date with main, skipping"
+            exit 0
+          fi
+
+          # Extract PR numbers from merge commits ("Merge pull request #NNN")
+          # and squash-merge commits ("feat: title (#NNN)")
+          PR_NUMS=$(git log "$MERGE_BASE"..origin/dev --format="%s" \
+            | grep -oE '#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -un \
+            | sort -rn)
+
+          # Build PR body
+          {
+            echo "## リリース内容"
+            echo ""
+            if [ -n "$PR_NUMS" ]; then
+              echo "### Merged PRs"
+              echo ""
+              for NUM in $PR_NUMS; do
+                LINE=$(gh pr view "$NUM" --repo "$REPO" \
+                  --json number,title \
+                  --jq '"- #\(.number) \(.title)"' 2>/dev/null || true)
+                [ -n "$LINE" ] && echo "$LINE"
+              done
+            else
+              echo "### Commits"
+              echo ""
+              git log "$MERGE_BASE"..origin/dev --no-merges --format="- %s" | head -30
+            fi
+          } > /tmp/pr-body.md
+
+          TITLE="chore: release $(date +'%Y-%m-%d')"
+
+          # Check if PR already exists (dev -> main)
+          PR_NUM=$(gh pr list \
+            --repo "$REPO" \
+            --base main \
+            --head dev \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "$PR_NUM" ]; then
+            gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head dev \
+              --title "$TITLE" \
+              --body-file /tmp/pr-body.md
+            echo "Created new release PR"
+          else
+            gh pr edit "$PR_NUM" \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file /tmp/pr-body.md
+            echo "Updated existing release PR #$PR_NUM"
+          fi


### PR DESCRIPTION
## Summary

- `dev` ブランチへの push をトリガーに、`dev` → `main` の release PR を自動作成・更新するワークフローを追加
- PR が未作成なら新規作成、既存 (open) なら本文とタイトルを最新の差分で上書き更新
- PR 本文には `dev` と `main` の merge base 以降にマージされた PR 一覧を掲載
- merge commit (`Merge pull request #NNN`) と squash merge (`title (#NNN)`) の両方に対応
- `dev` が `main` と差分ゼロの場合はスキップ

## 動作イメージ

`dev` に push → ワークフロー起動 → PR 本文自動生成:

```markdown
## リリース内容

### Merged PRs

- #123 feat: hogehoge
- #120 fix: fugafuga
- #115 chore: piyopiyo
```

## 権限

`GITHUB_TOKEN` のデフォルト権限 (`write`) で動作。追加のシークレット設定不要。

## Test plan

- [ ] `dev` への push 後にワークフローが起動し、`main` への PR が新規作成されることを確認
- [ ] 再度 `dev` に push した際に既存 PR の本文が更新されることを確認
- [ ] `dev` が `main` と差分ゼロの場合にワークフローがスキップされることを確認

closes #339