### PR TITLE
fix: relax Node engine constraint to allow Node 24+

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vitest-browser-react": "1.0.1"
   },
   "engines": {
-    "node": "^22.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.14.0",
   "pnpm": {


### PR DESCRIPTION
## Summary

- `package.json` の `engines.node` を `^22.0.0` から `>=22.0.0` に変更

## 背景

Dependabot の rebase が Node バージョン制約エラーで失敗していた。Dependabot の実行環境が Node 24 を使用しているが、プロジェクトの制約が `^22.0.0`（= `>=22.0.0 <23.0.0`）で Node 23 以降を除外していたため。

CI は引き続き Node 22 を使用するため、実行環境への影響はなし。