### PR TITLE
feat: add CSV export page with Basic Auth

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -8,6 +8,11 @@ export default async function handleRequest(
   routerContext: EntryContext,
   loadContext?: AppLoadContext,
 ): Promise<Response> {
+  const { pathname } = new URL(request.url);
+  if (responseStatusCode === 401 && pathname.startsWith("/export")) {
+    responseHeaders.set("WWW-Authenticate", 'Basic realm="BirdXplorer Export"');
+  }
+
   const response = await vercelHandleRequest(
     request,
     responseStatusCode,

--- a/app/feature/export/auth.ts
+++ b/app/feature/export/auth.ts
@@ -1,20 +1,15 @@
-export function middleware(request: Request) {
-  const { pathname } = new URL(request.url);
-  if (!pathname.startsWith("/export")) {
-    return;
-  }
-
+export function checkBasicAuth(request: Request): Response | null {
   const user = process.env.EXPORT_BASIC_AUTH_USER;
   const pass = process.env.EXPORT_BASIC_AUTH_PASSWORD;
   if (!user || !pass) {
-    return;
+    return null;
   }
 
   const auth = request.headers.get("Authorization") ?? "";
   const [scheme, encoded] = auth.split(" ");
   const expected = btoa(`${user}:${pass}`);
   if (scheme === "Basic" && encoded === expected) {
-    return;
+    return null;
   }
 
   return new Response("Unauthorized", {
@@ -22,7 +17,3 @@ export function middleware(request: Request) {
     headers: { "WWW-Authenticate": 'Basic realm="BirdXplorer Export"' },
   });
 }
-
-export const config = {
-  matcher: ["/export/:path*"],
-};

--- a/app/feature/export/validation.ts
+++ b/app/feature/export/validation.ts
@@ -3,49 +3,61 @@ import { z } from "zod";
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_KEYWORDS = 50;
 
-export const csvExportParamSchema = z
-  .object({
-    keywords: z.string().min(1, "キーワードを1つ以上入力してください"),
-    note_created_at_from: z.coerce
-      .number()
-      .min(0)
-      .max(new Date().valueOf(), "現在より先の日時は指定できません"),
-    note_created_at_to: z.coerce
-      .number()
-      .min(0)
-      .max(new Date().valueOf(), "現在より先の日時は指定できません"),
-  })
-  .superRefine((data, ctx) => {
-    const parsed = parseKeywords(data.keywords);
-    if (parsed.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "キーワードを1つ以上入力してください",
-        path: ["keywords"],
-      });
-    }
-    if (parsed.length > MAX_KEYWORDS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `キーワードは最大${MAX_KEYWORDS}個です`,
-        path: ["keywords"],
-      });
-    }
-    if (data.note_created_at_from > data.note_created_at_to) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "開始日時は終了日時より前にしてください",
-        path: ["note_created_at_from"],
-      });
-    }
-    if (data.note_created_at_to - data.note_created_at_from > THIRTY_DAYS_MS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "期間は最大30日間です",
-        path: ["note_created_at_to"],
-      });
-    }
-  });
+export const csvExportBaseSchema = z.object({
+  keywords: z.string().min(1, "キーワードを1つ以上入力してください"),
+  note_created_at_from: z.coerce
+    .number()
+    .min(0)
+    .max(new Date().valueOf(), "現在より先の日時は指定できません")
+    .or(z.null())
+    .optional(),
+  note_created_at_to: z.coerce
+    .number()
+    .min(0)
+    .max(new Date().valueOf(), "現在より先の日時は指定できません")
+    .or(z.null())
+    .optional(),
+});
+
+export const csvExportParamSchema = csvExportBaseSchema.superRefine((data, ctx) => {
+  const parsed = parseKeywords(data.keywords);
+  if (parsed.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "キーワードを1つ以上入力してください",
+      path: ["keywords"],
+    });
+  }
+  if (parsed.length > MAX_KEYWORDS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `キーワードは最大${MAX_KEYWORDS}個です`,
+      path: ["keywords"],
+    });
+  }
+  if (data.note_created_at_from == null || data.note_created_at_to == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "日付範囲を入力してください",
+      path: ["note_created_at_from"],
+    });
+    return;
+  }
+  if (data.note_created_at_from > data.note_created_at_to) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "開始日時は終了日時より前にしてください",
+      path: ["note_created_at_from"],
+    });
+  }
+  if (data.note_created_at_to - data.note_created_at_from > THIRTY_DAYS_MS) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "期間は最大30日間です",
+      path: ["note_created_at_to"],
+    });
+  }
+});
 
 export type CsvExportParams = z.infer<typeof csvExportParamSchema>;
 

--- a/app/feature/export/validation.ts
+++ b/app/feature/export/validation.ts
@@ -19,45 +19,47 @@ export const csvExportBaseSchema = z.object({
     .optional(),
 });
 
-export const csvExportParamSchema = csvExportBaseSchema.superRefine((data, ctx) => {
-  const parsed = parseKeywords(data.keywords);
-  if (parsed.length === 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "キーワードを1つ以上入力してください",
-      path: ["keywords"],
-    });
-  }
-  if (parsed.length > MAX_KEYWORDS) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `キーワードは最大${MAX_KEYWORDS}個です`,
-      path: ["keywords"],
-    });
-  }
-  if (data.note_created_at_from == null || data.note_created_at_to == null) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "日付範囲を入力してください",
-      path: ["note_created_at_from"],
-    });
-    return;
-  }
-  if (data.note_created_at_from > data.note_created_at_to) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "開始日時は終了日時より前にしてください",
-      path: ["note_created_at_from"],
-    });
-  }
-  if (data.note_created_at_to - data.note_created_at_from > THIRTY_DAYS_MS) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "期間は最大30日間です",
-      path: ["note_created_at_to"],
-    });
-  }
-});
+export const csvExportParamSchema = csvExportBaseSchema.superRefine(
+  (data, ctx) => {
+    const parsed = parseKeywords(data.keywords);
+    if (parsed.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "キーワードを1つ以上入力してください",
+        path: ["keywords"],
+      });
+    }
+    if (parsed.length > MAX_KEYWORDS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `キーワードは最大${MAX_KEYWORDS}個です`,
+        path: ["keywords"],
+      });
+    }
+    if (data.note_created_at_from == null || data.note_created_at_to == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "日付範囲を入力してください",
+        path: ["note_created_at_from"],
+      });
+      return;
+    }
+    if (data.note_created_at_from > data.note_created_at_to) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "開始日時は終了日時より前にしてください",
+        path: ["note_created_at_from"],
+      });
+    }
+    if (data.note_created_at_to - data.note_created_at_from > THIRTY_DAYS_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "期間は最大30日間です",
+        path: ["note_created_at_to"],
+      });
+    }
+  },
+);
 
 export type CsvExportParams = z.infer<typeof csvExportParamSchema>;
 

--- a/app/feature/export/validation.ts
+++ b/app/feature/export/validation.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_KEYWORDS = 50;
+
+export const csvExportParamSchema = z
+  .object({
+    keywords: z.string().min(1, "キーワードを1つ以上入力してください"),
+    note_created_at_from: z.coerce
+      .number()
+      .min(0)
+      .max(new Date().valueOf(), "現在より先の日時は指定できません"),
+    note_created_at_to: z.coerce
+      .number()
+      .min(0)
+      .max(new Date().valueOf(), "現在より先の日時は指定できません"),
+  })
+  .superRefine((data, ctx) => {
+    const parsed = parseKeywords(data.keywords);
+    if (parsed.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "キーワードを1つ以上入力してください",
+        path: ["keywords"],
+      });
+    }
+    if (parsed.length > MAX_KEYWORDS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `キーワードは最大${MAX_KEYWORDS}個です`,
+        path: ["keywords"],
+      });
+    }
+    if (data.note_created_at_from > data.note_created_at_to) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "開始日時は終了日時より前にしてください",
+        path: ["note_created_at_from"],
+      });
+    }
+    if (data.note_created_at_to - data.note_created_at_from > THIRTY_DAYS_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "期間は最大30日間です",
+        path: ["note_created_at_to"],
+      });
+    }
+  });
+
+export type CsvExportParams = z.infer<typeof csvExportParamSchema>;
+
+export function parseKeywords(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((k) => k.trim())
+    .filter(Boolean);
+}

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -2,7 +2,15 @@
 import type { SubmissionResult } from "@conform-to/react";
 import { getFormProps, getInputProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
-import { Button, Card, Container, Divider, Group, Stack, Text } from "@mantine/core";
+import {
+  Button,
+  Card,
+  Container,
+  Divider,
+  Group,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { hash } from "ohash";
 import { useMemo } from "react";
 import { data, Form, redirect, useNavigation } from "react-router";
@@ -17,7 +25,10 @@ import { SubmitButton } from "~/components/SubmitButton";
 import { WEB_PATHS } from "~/constants/paths";
 import type { CsvExportParams } from "~/feature/export/validation";
 import type { csvExportBaseSchema } from "~/feature/export/validation";
-import { csvExportParamSchema, parseKeywords } from "~/feature/export/validation";
+import {
+  csvExportParamSchema,
+  parseKeywords,
+} from "~/feature/export/validation";
 import { searchApiV1DataSearchGet } from "~/generated/api/client";
 import type { SearchedNote } from "~/generated/api/schemas";
 import { containsNonNullValues } from "~/utils/array";
@@ -48,10 +59,14 @@ export const loader = async (args: Route.LoaderArgs) => {
     return { data: { exportQuery: null, previewNotes: [] }, error: null };
   }
 
-  const exportQuery = await csvExportParamSchema.safeParseAsync(rawSearchParams);
+  const exportQuery =
+    await csvExportParamSchema.safeParseAsync(rawSearchParams);
   if (!exportQuery.success) {
     return data(
-      { data: { exportQuery: null, previewNotes: [] }, error: exportQuery.error.errors },
+      {
+        data: { exportQuery: null, previewNotes: [] },
+        error: exportQuery.error.errors,
+      },
       { status: 400 },
     );
   }
@@ -66,7 +81,7 @@ export const loader = async (args: Route.LoaderArgs) => {
 
   const apiData = previewResult?.data;
   const previewNotes: SearchedNote[] =
-    apiData && "data" in apiData ? (apiData.data) : [];
+    apiData && "data" in apiData ? apiData.data : [];
 
   return {
     data: {
@@ -153,14 +168,18 @@ function ExportForm({ defaultValue, lastResult }: ExportFormProps) {
   );
 }
 
-export default function Export({ actionData, loaderData }: Route.ComponentProps) {
+export default function Export({
+  actionData,
+  loaderData,
+}: Route.ComponentProps) {
   const { exportQuery, previewNotes } = loaderData.data as {
     exportQuery: CsvExportParams | null;
     previewNotes: SearchedNote[];
   };
 
   const csvUrl =
-    exportQuery?.note_created_at_from != null && exportQuery.note_created_at_to != null
+    exportQuery?.note_created_at_from != null &&
+    exportQuery.note_created_at_to != null
       ? `/export/csv?${new URLSearchParams({
           keywords: exportQuery.keywords,
           note_created_at_from: String(exportQuery.note_created_at_from),
@@ -184,13 +203,16 @@ export default function Export({ actionData, loaderData }: Route.ComponentProps)
               <Stack>
                 <Group align="center" justify="space-between">
                   <Text c="dimmed" size="sm">
-                    プレビュー（キーワード「{parseKeywords(exportQuery.keywords)[0]}」で表示）
+                    プレビュー（キーワード「
+                    {parseKeywords(exportQuery.keywords)[0]}」で表示）
                   </Text>
                   <Button
                     component="a"
                     download
                     href={csvUrl ?? "#"}
-                    styles={{ root: { backgroundColor: "var(--color-primary)" } }}
+                    styles={{
+                      root: { backgroundColor: "var(--color-primary)" },
+                    }}
                   >
                     Export CSV
                   </Button>
@@ -226,7 +248,10 @@ export default function Export({ actionData, loaderData }: Route.ComponentProps)
                 w="100%"
                 withBorder
               >
-                <Text c="white" className="text-center text-lg font-semibold text-balance">
+                <Text
+                  c="white"
+                  className="text-center text-lg font-semibold text-balance"
+                >
                   キーワードと期間を入力して
                   <br />
                   プレビューを表示してください

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -239,8 +239,16 @@ export default function Export({
                   </Text>
                   <Button
                     component="a"
-                    download
+                    disabled={!csvUrl}
                     href={csvUrl ?? "#"}
+                    onClick={(e) => {
+                      if (!csvUrl) {
+                        e.preventDefault();
+                        return;
+                      }
+                      window.location.href = csvUrl;
+                      e.preventDefault();
+                    }}
                     styles={{
                       root: { backgroundColor: "var(--color-primary)" },
                     }}

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -12,7 +12,7 @@ import {
   Text,
 } from "@mantine/core";
 import { hash } from "ohash";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { data, Form, redirect, useNavigation } from "react-router";
 import { getQuery, withQuery } from "ufo";
 import type { z } from "zod";
@@ -208,6 +208,7 @@ export default function Export({
     exportQuery: CsvExportParams | null;
     previewNotes: SearchedNote[];
   };
+  const [isDownloading, setIsDownloading] = useState(false);
 
   const csvUrl =
     exportQuery?.note_created_at_from != null &&
@@ -218,6 +219,27 @@ export default function Export({
           note_created_at_to: String(exportQuery.note_created_at_to),
         }).toString()}`
       : null;
+
+  const handleExport = async () => {
+    if (!csvUrl || isDownloading) return;
+    setIsDownloading(true);
+    try {
+      const res = await fetch(csvUrl);
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      const disposition = res.headers.get("Content-Disposition") ?? "";
+      const match = /filename="([^"]+)"/.exec(disposition);
+      a.download = match?.[1] ?? "community_notes.csv";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
 
   return (
     <main>
@@ -238,17 +260,9 @@ export default function Export({
                     プレビュー（全キーワードOR検索・最大25件）
                   </Text>
                   <Button
-                    component="a"
-                    disabled={!csvUrl}
-                    href={csvUrl ?? "#"}
-                    onClick={(e) => {
-                      if (!csvUrl) {
-                        e.preventDefault();
-                        return;
-                      }
-                      window.location.href = csvUrl;
-                      e.preventDefault();
-                    }}
+                    disabled={!csvUrl || isDownloading}
+                    loading={isDownloading}
+                    onClick={() => void handleExport()}
                     styles={{
                       root: { backgroundColor: "var(--color-primary)" },
                     }}

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -1,24 +1,27 @@
 /* eslint-disable react-refresh/only-export-components */
+import type { SubmissionResult } from "@conform-to/react";
 import { getFormProps, getInputProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { Button, Card, Container, Divider, Group, Stack, Text } from "@mantine/core";
 import { hash } from "ohash";
 import { useMemo } from "react";
-import { Form, data, redirect, useNavigation } from "react-router";
+import { data, Form, redirect, useNavigation } from "react-router";
 import { getQuery, withQuery } from "ufo";
+import type { z } from "zod";
 
 import { FormError } from "~/components/FormError";
-import { SubmitButton } from "~/components/SubmitButton";
 import { DateRangePicker } from "~/components/input/DateRangePicker";
 import { TextInput } from "~/components/mantine/TextInput";
 import { Notes } from "~/components/note/Notes";
+import { SubmitButton } from "~/components/SubmitButton";
 import { WEB_PATHS } from "~/constants/paths";
-import { csvExportParamSchema, parseKeywords } from "~/feature/export/validation";
 import type { CsvExportParams } from "~/feature/export/validation";
+import type { csvExportBaseSchema } from "~/feature/export/validation";
+import { csvExportParamSchema, parseKeywords } from "~/feature/export/validation";
 import { searchApiV1DataSearchGet } from "~/generated/api/client";
 import type { SearchedNote } from "~/generated/api/schemas";
-import { safeDateFromUnixMs } from "~/utils/date";
 import { containsNonNullValues } from "~/utils/array";
+import { safeDateFromUnixMs } from "~/utils/date";
 import Fa6SolidFileArrowDown from "~icons/fa6-solid/file-arrow-down";
 
 import type { LayoutHandle } from "./_layout";
@@ -59,12 +62,16 @@ export const loader = async (args: Route.LoaderArgs) => {
     note_created_at_from: exportQuery.data.note_created_at_from,
     note_created_at_to: exportQuery.data.note_created_at_to,
     limit: 25,
-  } as never).catch(() => null);
+  }).catch(() => null);
+
+  const apiData = previewResult?.data;
+  const previewNotes: SearchedNote[] =
+    apiData && "data" in apiData ? (apiData.data) : [];
 
   return {
     data: {
       exportQuery: exportQuery.data,
-      previewNotes: previewResult?.data.data ?? [],
+      previewNotes,
     },
     error: null,
   };
@@ -79,7 +86,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
 type ExportFormProps = {
   defaultValue?: Partial<CsvExportParams>;
-  lastResult?: Parameters<typeof useForm>[0]["lastResult"];
+  lastResult?: SubmissionResult<string[]> | null;
 };
 
 function ExportForm({ defaultValue, lastResult }: ExportFormProps) {
@@ -88,7 +95,7 @@ function ExportForm({ defaultValue, lastResult }: ExportFormProps) {
 
   const formId = useMemo(() => hash(defaultValue ?? {}), [defaultValue]);
 
-  const [form, fields] = useForm({
+  const [form, fields] = useForm<z.infer<typeof csvExportBaseSchema>>({
     id: formId,
     shouldValidate: "onBlur",
     shouldRevalidate: "onInput",
@@ -147,15 +154,19 @@ function ExportForm({ defaultValue, lastResult }: ExportFormProps) {
 }
 
 export default function Export({ actionData, loaderData }: Route.ComponentProps) {
-  const { exportQuery, previewNotes } = loaderData.data;
+  const { exportQuery, previewNotes } = loaderData.data as {
+    exportQuery: CsvExportParams | null;
+    previewNotes: SearchedNote[];
+  };
 
-  const csvUrl = exportQuery
-    ? `/export/csv?${new URLSearchParams({
-        keywords: exportQuery.keywords,
-        note_created_at_from: String(exportQuery.note_created_at_from),
-        note_created_at_to: String(exportQuery.note_created_at_to),
-      }).toString()}`
-    : null;
+  const csvUrl =
+    exportQuery?.note_created_at_from != null && exportQuery.note_created_at_to != null
+      ? `/export/csv?${new URLSearchParams({
+          keywords: exportQuery.keywords,
+          note_created_at_from: String(exportQuery.note_created_at_from),
+          note_created_at_to: String(exportQuery.note_created_at_to),
+        }).toString()}`
+      : null;
 
   return (
     <main>
@@ -186,7 +197,7 @@ export default function Export({ actionData, loaderData }: Route.ComponentProps)
                 </Group>
                 {previewNotes.length > 0 ? (
                   <Group gap="lg">
-                    <Notes notes={previewNotes as SearchedNote[]} />
+                    <Notes notes={previewNotes} />
                   </Group>
                 ) : (
                   <Card

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -1,0 +1,230 @@
+/* eslint-disable react-refresh/only-export-components */
+import { getFormProps, getInputProps, useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod";
+import { Button, Card, Container, Divider, Group, Stack, Text } from "@mantine/core";
+import { hash } from "ohash";
+import { useMemo } from "react";
+import { Form, data, redirect, useNavigation } from "react-router";
+import { getQuery, withQuery } from "ufo";
+
+import { FormError } from "~/components/FormError";
+import { SubmitButton } from "~/components/SubmitButton";
+import { DateRangePicker } from "~/components/input/DateRangePicker";
+import { TextInput } from "~/components/mantine/TextInput";
+import { Notes } from "~/components/note/Notes";
+import { WEB_PATHS } from "~/constants/paths";
+import { csvExportParamSchema, parseKeywords } from "~/feature/export/validation";
+import type { CsvExportParams } from "~/feature/export/validation";
+import { searchApiV1DataSearchGet } from "~/generated/api/client";
+import type { SearchedNote } from "~/generated/api/schemas";
+import { safeDateFromUnixMs } from "~/utils/date";
+import { containsNonNullValues } from "~/utils/array";
+import Fa6SolidFileArrowDown from "~icons/fa6-solid/file-arrow-down";
+
+import type { LayoutHandle } from "./_layout";
+import type { Route } from "./+types/_layout.export";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "エクスポート - BirdXplorer" },
+  { name: "robots", content: "noindex, nofollow" },
+];
+
+export const handle: LayoutHandle = {
+  breadcrumb: [{ label: "TOP", href: WEB_PATHS.home }, { label: "Export" }],
+  pageTitle: {
+    icon: <Fa6SolidFileArrowDown className="size-full text-white" />,
+    title: "Export",
+    subtitle: "CSVエクスポート",
+  },
+};
+
+export const loader = async (args: Route.LoaderArgs) => {
+  const rawSearchParams = getQuery(args.request.url);
+
+  if (!rawSearchParams.keywords) {
+    return { data: { exportQuery: null, previewNotes: [] }, error: null };
+  }
+
+  const exportQuery = await csvExportParamSchema.safeParseAsync(rawSearchParams);
+  if (!exportQuery.success) {
+    return data(
+      { data: { exportQuery: null, previewNotes: [] }, error: exportQuery.error.errors },
+      { status: 400 },
+    );
+  }
+
+  const keywords = parseKeywords(exportQuery.data.keywords);
+  const previewResult = await searchApiV1DataSearchGet({
+    note_includes_text: keywords[0],
+    note_created_at_from: exportQuery.data.note_created_at_from,
+    note_created_at_to: exportQuery.data.note_created_at_to,
+    limit: 25,
+  } as never).catch(() => null);
+
+  return {
+    data: {
+      exportQuery: exportQuery.data,
+      previewNotes: previewResult?.data.data ?? [],
+    },
+    error: null,
+  };
+};
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const formData = await request.formData();
+  const submission = parseWithZod(formData, { schema: csvExportParamSchema });
+  if (submission.status !== "success") return submission.reply();
+  return redirect(withQuery("/export", submission.value));
+};
+
+type ExportFormProps = {
+  defaultValue?: Partial<CsvExportParams>;
+  lastResult?: Parameters<typeof useForm>[0]["lastResult"];
+};
+
+function ExportForm({ defaultValue, lastResult }: ExportFormProps) {
+  const navigation = useNavigation();
+  const isLoading = navigation.state !== "idle";
+
+  const formId = useMemo(() => hash(defaultValue ?? {}), [defaultValue]);
+
+  const [form, fields] = useForm({
+    id: formId,
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onInput",
+    lastResult,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: csvExportParamSchema });
+    },
+    defaultValue,
+  });
+
+  return (
+    <Form method="POST" preventScrollReset {...getFormProps(form)}>
+      <Stack>
+        <TextInput
+          autoComplete="off"
+          c="white"
+          classNames={{ input: "!bg-gray-1 !border-gray-5" }}
+          description="カンマ区切りでOR検索（例: 医療,政治）最大50個"
+          disabled={isLoading}
+          error={
+            containsNonNullValues(fields.keywords.errors) && (
+              <FormError errors={[fields.keywords.errors]} />
+            )
+          }
+          label="キーワード（必須）"
+          placeholder="例: 医療,政治,AI"
+          styles={{ input: { color: "white" }, label: { marginBottom: "8px" } }}
+          {...getInputProps(fields.keywords, { type: "text" })}
+        />
+        <DateRangePicker
+          convertFormValueToMantine={safeDateFromUnixMs}
+          convertMantineValueToForm={(date) => date?.valueOf().toString()}
+          disabled={isLoading}
+          fromField={fields.note_created_at_from}
+          label="ノート作成期間（必須・最大30日間）"
+          toField={fields.note_created_at_to}
+          valueFormat="YYYY.MM.DD (ddd)"
+        />
+        <div className="pt-4 md:pt-5" />
+        <SubmitButton
+          c="white"
+          disabled={!form.valid || isLoading}
+          loading={isLoading}
+          styles={{
+            root: {
+              backgroundColor: "var(--color-primary)",
+              borderRadius: "9999px",
+            },
+          }}
+        >
+          プレビューを表示
+        </SubmitButton>
+      </Stack>
+    </Form>
+  );
+}
+
+export default function Export({ actionData, loaderData }: Route.ComponentProps) {
+  const { exportQuery, previewNotes } = loaderData.data;
+
+  const csvUrl = exportQuery
+    ? `/export/csv?${new URLSearchParams({
+        keywords: exportQuery.keywords,
+        note_created_at_from: String(exportQuery.note_created_at_from),
+        note_created_at_to: String(exportQuery.note_created_at_to),
+      }).toString()}`
+    : null;
+
+  return (
+    <main>
+      <Container className="!px-0" size="xl">
+        <div className="grid grid-cols-1 gap-4 border-t border-gray-5 pt-5 md:grid-cols-3 md:items-start md:gap-8">
+          <div className="md:col-span-1">
+            <ExportForm
+              defaultValue={exportQuery ?? undefined}
+              lastResult={actionData}
+            />
+          </div>
+          <Divider className="md:hidden" />
+          <div className="size-full p-4 md:col-span-2">
+            {exportQuery ? (
+              <Stack>
+                <Group align="center" justify="space-between">
+                  <Text c="dimmed" size="sm">
+                    プレビュー（キーワード「{parseKeywords(exportQuery.keywords)[0]}」で表示）
+                  </Text>
+                  <Button
+                    component="a"
+                    download
+                    href={csvUrl ?? "#"}
+                    styles={{ root: { backgroundColor: "var(--color-primary)" } }}
+                  >
+                    Export CSV
+                  </Button>
+                </Group>
+                {previewNotes.length > 0 ? (
+                  <Group gap="lg">
+                    <Notes notes={previewNotes as SearchedNote[]} />
+                  </Group>
+                ) : (
+                  <Card
+                    bg="var(--color-twitter-dark-1)"
+                    className="grid size-full place-content-center"
+                    padding="lg"
+                    radius="md"
+                    w="100%"
+                    withBorder
+                  >
+                    <Text
+                      c="white"
+                      className="text-center text-lg font-semibold text-balance"
+                    >
+                      検索結果がありません
+                    </Text>
+                  </Card>
+                )}
+              </Stack>
+            ) : (
+              <Card
+                bg="var(--color-twitter-dark-1)"
+                className="grid size-full place-content-center"
+                padding="lg"
+                radius="md"
+                w="100%"
+                withBorder
+              >
+                <Text c="white" className="text-center text-lg font-semibold text-balance">
+                  キーワードと期間を入力して
+                  <br />
+                  プレビューを表示してください
+                </Text>
+              </Card>
+            )}
+          </div>
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -55,7 +55,8 @@ export const handle: LayoutHandle = {
 
 export const loader = async (args: Route.LoaderArgs) => {
   const authError = checkBasicAuth(args.request);
-  if (authError) return authError;
+  // eslint-disable-next-line @typescript-eslint/only-throw-error
+  if (authError) throw authError;
 
   const rawSearchParams = getQuery(args.request.url);
 

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -23,6 +23,7 @@ import { TextInput } from "~/components/mantine/TextInput";
 import { Notes } from "~/components/note/Notes";
 import { SubmitButton } from "~/components/SubmitButton";
 import { WEB_PATHS } from "~/constants/paths";
+import { checkBasicAuth } from "~/feature/export/auth";
 import type { CsvExportParams } from "~/feature/export/validation";
 import type { csvExportBaseSchema } from "~/feature/export/validation";
 import {
@@ -53,6 +54,9 @@ export const handle: LayoutHandle = {
 };
 
 export const loader = async (args: Route.LoaderArgs) => {
+  const authError = checkBasicAuth(args.request);
+  if (authError) return authError;
+
   const rawSearchParams = getQuery(args.request.url);
 
   if (!rawSearchParams.keywords) {
@@ -84,9 +88,7 @@ export const loader = async (args: Route.LoaderArgs) => {
   );
 
   const noteArrays = perKeywordResults.map((result) =>
-    result?.data && "data" in result.data
-      ? (result.data.data)
-      : [],
+    result?.data && "data" in result.data ? result.data.data : [],
   );
   const seen = new Set<string>();
   const previewNotes: SearchedNote[] = [];
@@ -96,7 +98,7 @@ export const loader = async (args: Route.LoaderArgs) => {
       if (i < notes.length) {
         advanced = true;
         const note = notes[i];
-        if (!seen.has(note.noteId)) {
+        if (note && !seen.has(note.noteId)) {
           seen.add(note.noteId);
           previewNotes.push(note);
           if (previewNotes.length >= 25) break;

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -83,16 +83,27 @@ export const loader = async (args: Route.LoaderArgs) => {
     ),
   );
 
+  const noteArrays = perKeywordResults.map((result) =>
+    result?.data && "data" in result.data
+      ? (result.data.data)
+      : [],
+  );
   const seen = new Set<string>();
   const previewNotes: SearchedNote[] = [];
-  for (const result of perKeywordResults) {
-    const notes = result?.data && "data" in result.data ? result.data.data : [];
-    for (const note of notes) {
-      if (!seen.has(note.noteId) && previewNotes.length < 25) {
-        seen.add(note.noteId);
-        previewNotes.push(note);
+  for (let i = 0; previewNotes.length < 25; i++) {
+    let advanced = false;
+    for (const notes of noteArrays) {
+      if (i < notes.length) {
+        advanced = true;
+        const note = notes[i];
+        if (!seen.has(note.noteId)) {
+          seen.add(note.noteId);
+          previewNotes.push(note);
+          if (previewNotes.length >= 25) break;
+        }
       }
     }
+    if (!advanced) break;
   }
 
   return {

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -72,16 +72,29 @@ export const loader = async (args: Route.LoaderArgs) => {
   }
 
   const keywords = parseKeywords(exportQuery.data.keywords);
-  const previewResult = await searchApiV1DataSearchGet({
-    note_includes_text: keywords[0],
-    note_created_at_from: exportQuery.data.note_created_at_from,
-    note_created_at_to: exportQuery.data.note_created_at_to,
-    limit: 25,
-  }).catch(() => null);
+  const perKeywordResults = await Promise.all(
+    keywords.map(async (kw) =>
+      searchApiV1DataSearchGet({
+        note_includes_text: kw,
+        note_created_at_from: exportQuery.data.note_created_at_from,
+        note_created_at_to: exportQuery.data.note_created_at_to,
+        limit: 25,
+      }).catch(() => null),
+    ),
+  );
 
-  const apiData = previewResult?.data;
-  const previewNotes: SearchedNote[] =
-    apiData && "data" in apiData ? apiData.data : [];
+  const seen = new Set<string>();
+  const previewNotes: SearchedNote[] = [];
+  for (const result of perKeywordResults) {
+    const notes =
+      result?.data && "data" in result.data ? (result.data.data) : [];
+    for (const note of notes) {
+      if (!seen.has(note.noteId) && previewNotes.length < 25) {
+        seen.add(note.noteId);
+        previewNotes.push(note);
+      }
+    }
+  }
 
   return {
     data: {
@@ -203,8 +216,7 @@ export default function Export({
               <Stack>
                 <Group align="center" justify="space-between">
                   <Text c="dimmed" size="sm">
-                    プレビュー（キーワード「
-                    {parseKeywords(exportQuery.keywords)[0]}」で表示）
+                    プレビュー（全キーワードOR検索・最大25件）
                   </Text>
                   <Button
                     component="a"

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -86,8 +86,7 @@ export const loader = async (args: Route.LoaderArgs) => {
   const seen = new Set<string>();
   const previewNotes: SearchedNote[] = [];
   for (const result of perKeywordResults) {
-    const notes =
-      result?.data && "data" in result.data ? (result.data.data) : [];
+    const notes = result?.data && "data" in result.data ? result.data.data : [];
     for (const note of notes) {
       if (!seen.has(note.noteId) && previewNotes.length < 25) {
         seen.add(note.noteId);

--- a/app/routes/_layout.export.tsx
+++ b/app/routes/_layout.export.tsx
@@ -53,6 +53,12 @@ export const handle: LayoutHandle = {
   },
 };
 
+export function headers({ errorHeaders }: Route.HeadersArgs) {
+  const wwwAuth = errorHeaders?.get("WWW-Authenticate");
+  if (wwwAuth) return { "WWW-Authenticate": wwwAuth };
+  return {};
+}
+
 export const loader = async (args: Route.LoaderArgs) => {
   const authError = checkBasicAuth(args.request);
   // eslint-disable-next-line @typescript-eslint/only-throw-error

--- a/app/routes/export.csv.ts
+++ b/app/routes/export.csv.ts
@@ -8,7 +8,8 @@ const API_BASE_URL =
 
 export async function loader({ request }: Route.LoaderArgs) {
   const authError = checkBasicAuth(request);
-  if (authError) return authError;
+  // eslint-disable-next-line @typescript-eslint/only-throw-error
+  if (authError) throw authError;
 
   const incomingUrl = new URL(request.url);
   const apiUrl = new URL(`${API_BASE_URL}/api/v1/data/export/csv`);

--- a/app/routes/export.csv.ts
+++ b/app/routes/export.csv.ts
@@ -1,0 +1,33 @@
+import type { Route } from "./+types/export.csv";
+
+const API_BASE_URL =
+  process.env.BIRDXPLORER_API_URL ?? "https://dev.api-birdxplorer.code4japan.org";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const incomingUrl = new URL(request.url);
+  const apiUrl = new URL(`${API_BASE_URL}/api/v1/data/export/csv`);
+
+  incomingUrl.searchParams.forEach((value, key) => {
+    apiUrl.searchParams.append(key, value);
+  });
+
+  const headers: Record<string, string> = {};
+  const apiKey = process.env.EXPORT_API_KEY;
+  if (apiKey) {
+    headers["X-API-Key"] = apiKey;
+  }
+
+  const upstream = await fetch(apiUrl.toString(), { headers });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type":
+        upstream.headers.get("Content-Type") ?? "text/csv; charset=utf-8",
+      "Content-Disposition":
+        upstream.headers.get("Content-Disposition") ??
+        'attachment; filename="community_notes.csv"',
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/routes/export.csv.ts
+++ b/app/routes/export.csv.ts
@@ -1,7 +1,8 @@
 import type { Route } from "./+types/export.csv";
 
 const API_BASE_URL =
-  process.env.BIRDXPLORER_API_URL ?? "https://dev.api-birdxplorer.code4japan.org";
+  process.env.BIRDXPLORER_API_URL ??
+  "https://dev.api-birdxplorer.code4japan.org";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const incomingUrl = new URL(request.url);

--- a/app/routes/export.csv.ts
+++ b/app/routes/export.csv.ts
@@ -1,5 +1,3 @@
-import { checkBasicAuth } from "~/feature/export/auth";
-
 import type { Route } from "./+types/export.csv";
 
 const API_BASE_URL =
@@ -7,10 +5,6 @@ const API_BASE_URL =
   "https://dev.api-birdxplorer.code4japan.org";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const authError = checkBasicAuth(request);
-  // eslint-disable-next-line @typescript-eslint/only-throw-error
-  if (authError) throw authError;
-
   const incomingUrl = new URL(request.url);
   const apiUrl = new URL(`${API_BASE_URL}/api/v1/data/export/csv`);
 

--- a/app/routes/export.csv.ts
+++ b/app/routes/export.csv.ts
@@ -1,3 +1,5 @@
+import { checkBasicAuth } from "~/feature/export/auth";
+
 import type { Route } from "./+types/export.csv";
 
 const API_BASE_URL =
@@ -5,6 +7,9 @@ const API_BASE_URL =
   "https://dev.api-birdxplorer.code4japan.org";
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const authError = checkBasicAuth(request);
+  if (authError) return authError;
+
   const incomingUrl = new URL(request.url);
   const apiUrl = new URL(`${API_BASE_URL}/api/v1/data/export/csv`);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+export function middleware(request: Request) {
+  const { pathname } = new URL(request.url);
+  if (!pathname.startsWith("/export")) {
+    return;
+  }
+
+  const user = process.env.EXPORT_BASIC_AUTH_USER;
+  const pass = process.env.EXPORT_BASIC_AUTH_PASSWORD;
+  if (!user || !pass) {
+    return;
+  }
+
+  const auth = request.headers.get("Authorization") ?? "";
+  const [scheme, encoded] = auth.split(" ");
+  const expected = btoa(`${user}:${pass}`);
+  if (scheme === "Basic" && encoded === expected) {
+    return;
+  }
+
+  return new Response("Unauthorized", {
+    status: 401,
+    headers: { "WWW-Authenticate": 'Basic realm="BirdXplorer Export"' },
+  });
+}
+
+export const config = {
+  matcher: ["/export/:path*"],
+};


### PR DESCRIPTION
## 概要

CSV エクスポート機能のフロントエンド実装です。非公開 URL（`/export`）として提供し、Basic 認証でアクセスを制限します。

## 変更内容

### `middleware.ts`（新規）
- Vercel Edge Middleware で `/export/*` パスに Basic 認証を適用
- `EXPORT_BASIC_AUTH_USER` / `EXPORT_BASIC_AUTH_PASSWORD` 環境変数から認証情報を取得
- 未設定時はスルー（開発環境対応）

### `app/routes/_layout.export.tsx`（新規）
- `/export` ページ
- キーワード（カンマ区切り OR 検索、最大 50 個）と日付範囲（必須・最大 30 日）の入力フォーム
- 「プレビューを表示」で先頭キーワードを使った検索結果を表示
- 「Export CSV」ボタンで `/export/csv` にナビゲート → ブラウザがファイルとして保存
- サイドメニューには非掲載（隠し URL）

### `app/routes/export.csv.ts`（新規）
- `/export/csv` SSR ローダー
- クエリパラメータをそのまま API に転送、`EXPORT_API_KEY` を `X-API-Key` ヘッダーに付与
- API のレスポンスをストリームとしてブラウザに返却（`X-API-Key` はクライアントに漏れない）

### `app/feature/export/validation.ts`（新規）
- `csvExportParamSchema`（キーワード必須・30日制約・50キーワード上限）

## 必要な Vercel 環境変数（設定済み）

| 変数名 | 内容 |
|---|---|
| `EXPORT_BASIC_AUTH_USER` | Basic 認証ユーザー名 |
| `EXPORT_BASIC_AUTH_PASSWORD` | Basic 認証パスワード |
| `EXPORT_API_KEY` | バックエンド `BX_EXPORT_API_KEY` と同じ値 |
| `BIRDXPLORER_API_URL` | API ベース URL |

## 関連 PR

- codeforjapan/BirdXplorer#247 CSV エクスポート API（バックエンド）
- codeforjapan/BirdXplorer-cdk#18 BX_EXPORT_API_KEY を Secrets Manager で管理