### PR TITLE
chore: upgrade Node.js requirement to 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vitest-browser-react": "1.0.1"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@10.14.0",
   "pnpm": {


### PR DESCRIPTION
## 概要

Node.js の要求バージョンを 22 → 24 に引き上げます。

## 変更内容

`package.json` の `engines.node` を `>=22.0.0` → `>=24.0.0` に変更。

CI は `node-version-file: package.json` で読んでいるため、自動的に Node 24 でビルド・テストが走ります。

## 背景

- GitHub Actions は 2026/6/16 からランナーを Node 24 に移行済み（CI に `Node.js 20 is deprecated` 警告が出ていた）
- Node 24 は現行の Active LTS
- Node 22 → 24 の破壊的変更はほぼなく、典型的な React/Vite アプリへの影響なし

## マージ後の追加作業

Vercel の **Project Settings → Functions → Node.js Version** を `24.x` に変更してください（コードの変更だけでは Vercel のランタイムは変わりません）。