### PR TITLE
chore: upgrade vitest / @vitest/browser / @vitest/browser-playwright to 4.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "5.2.0",
-    "@vitest/browser": "4.1.4",
-    "@vitest/browser-playwright": "4.1.4",
+    "@vitest/browser": "4.1.9",
+    "@vitest/browser-playwright": "4.1.9",
     "autoprefixer": "10.5.0",
     "eslint": "9.39.4",
     "eslint-config-flat-gitignore": "2.3.0",
@@ -87,7 +87,7 @@
     "unplugin-icons": "23.0.1",
     "vite": "8.0.16",
     "vite-tsconfig-paths": "6.1.1",
-    "vitest": "4.1.5",
+    "vitest": "4.1.9",
     "vitest-browser-react": "1.0.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,11 +127,11 @@ importers:
         specifier: 5.2.0
         version: 5.2.0(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
       '@vitest/browser':
-        specifier: 4.1.4
-        version: 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)
+        specifier: 4.1.9
+        version: 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)
       '@vitest/browser-playwright':
-        specifier: 4.1.4
-        version: 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)
+        specifier: 4.1.9
+        version: 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)
       autoprefixer:
         specifier: 10.5.0
         version: 10.5.0(postcss@8.5.14)
@@ -208,11 +208,11 @@ importers:
         specifier: 6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
       vitest:
-        specifier: 4.1.5
-        version: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.4)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+        specifier: 4.1.9
+        version: 4.1.9(@types/node@25.6.2)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
       vitest-browser-react:
         specifier: 1.0.1
-        version: 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vitest/browser@4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.5)
+        version: 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vitest/browser@4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
 
 packages:
 
@@ -2081,33 +2081,22 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/browser-playwright@4.1.4':
-    resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}
+  '@vitest/browser-playwright@4.1.9':
+    resolution: {integrity: sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.4
+      vitest: 4.1.9
 
-  '@vitest/browser@4.1.4':
-    resolution: {integrity: sha512-TrNaY/yVOwxtrxNsDUC/wQ56xSwplpytTeRAqF/197xV/ZddxxulBsxR6TrhVMyniJmp9in8d5u0AcDaNRY30w==}
+  '@vitest/browser@4.1.9':
+    resolution: {integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==}
     peerDependencies:
-      vitest: 4.1.4
+      vitest: 4.1.9
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2117,29 +2106,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
-
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
-
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
-
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4407,10 +4387,6 @@ packages:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -4804,20 +4780,20 @@ packages:
       '@types/react-dom':
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4912,18 +4888,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -6994,96 +6958,75 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)
-      '@vitest/mocker': 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      '@vitest/browser': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.4)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      vitest: 4.1.9(@types/node@25.6.2)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)':
+  '@vitest/browser@4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
-      '@vitest/utils': 4.1.4
+      '@vitest/mocker': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.4)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
-      ws: 8.20.0
+      vitest: 4.1.9(@types/node@25.6.2)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/expect@4.1.5':
+  '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))':
+  '@vitest/mocker@4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))':
     dependencies:
-      '@vitest/spy': 4.1.4
+      '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.8.2(@types/node@25.6.2)(typescript@5.9.3)
       vite: 8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1)
 
-  '@vitest/mocker@4.1.5(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.8.2(@types/node@25.6.2)(typescript@5.9.3)
-      vite: 8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1)
-
-  '@vitest/pretty-format@4.1.4':
+  '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/runner@4.1.9':
     dependencies:
-      tinyrainbow: 3.1.0
-
-  '@vitest/runner@4.1.5':
-    dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.4': {}
+  '@vitest/spy@4.1.9': {}
 
-  '@vitest/spy@4.1.5': {}
-
-  '@vitest/utils@4.1.4':
+  '@vitest/utils@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.5':
-    dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -9581,11 +9524,6 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9906,25 +9844,25 @@ snapshots:
       sugarss: 5.0.1(postcss@8.5.14)
       yaml: 2.7.1
 
-  vitest-browser-react@1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vitest/browser@4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.5):
+  vitest-browser-react@1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vitest/browser@4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@vitest/browser': 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)
+      '@vitest/browser': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.4)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      vitest: 4.1.9(@types/node@25.6.2)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  vitest@4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.4)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1)):
+  vitest@4.1.9(@types/node@25.6.2)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9934,13 +9872,13 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.2
-      '@vitest/browser-playwright': 4.1.4(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.9(msw@2.8.2(@types/node@25.6.2)(typescript@5.9.3))(playwright@1.59.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.14))(yaml@2.7.1))(vitest@4.1.9)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
@@ -10040,10 +9978,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.20.0: {}
-
-  ws@8.21.0:
-    optional: true
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0:
     optional: true


### PR DESCRIPTION
## 概要

Dependabot PR #383 は `vitest` のみ 4.1.5→4.1.9 に上げており、`@vitest/browser` (4.1.4) と `@vitest/browser-playwright` (4.1.4) が古いままでした。

vitest 4.1.9 でブラウザセッションの接続プロトコルが変更されたため、バージョン不一致により CI で `"Failed to connect to the browser session within the timeout"` が再現性をもって発生していました。

3パッケージを 4.1.9 に揃えることで解消します。

## 変更内容

- `vitest` 4.1.5 → 4.1.9
- `@vitest/browser` 4.1.4 → 4.1.9
- `@vitest/browser-playwright` 4.1.4 → 4.1.9

## 関連

Dependabot PR #383 はこの PR のマージ後にクローズしてください。